### PR TITLE
fix: handle non-object properties in environment config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# Editor configuration, see http://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+max_line_length = 0
+trim_trailing_whitespace = false

--- a/src/store.js
+++ b/src/store.js
@@ -71,6 +71,10 @@ export function evaluatePredicates(version, context, config) {
   }
 
   function evaluateBranch(context, config, prefix, disabled, entry) {
+    if (!config || typeof config !== 'object') {
+      return;
+    }
+
     if (config._predicate) {
       const result = evaluate(context, config._predicate);
       if (result.rejected) {

--- a/src/tests/store.test.js
+++ b/src/tests/store.test.js
@@ -7,6 +7,30 @@ import Store, { evaluatePredicates } from '../store.js';
 
 describe('store.js', () => {
   describe('evaluatePredicates', () => {
+  	it('should not throw error when properties are not objects', () => {
+  	  // Arrange
+      const config = {
+        _published: 1584475383.3865728,
+        _experiments: [{
+          id: '0f39849197',
+          web: {
+            dependencies: 'function() {}',
+            count: 1,
+            choice: true,
+            none: null
+          }
+        }]
+      };
+
+      // Act
+      const context = new Context();
+      context.initialize(123, 321, {});
+
+      assert.doesNotThrow(() => {
+        evaluatePredicates(2, context, config);
+      });
+    });
+
     it('should reject all keys if the context doesn\'t satisfy the experiment level predicate', () => {
       const config = {
         "_published": 1584475383.3865728,


### PR DESCRIPTION
strings in particular caused "maximum call stack exceeded" errors because Object.keys('abc') returns an array of indexes to each character, which are in turn strings themselves

RKT-7629