### PR TITLE
fix: fixed check for active contexts

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -186,25 +186,35 @@ function EvolvStore(options) {
     configKeyStates.active.clear();
     configKeyStates.entry.clear();
     effectiveGenome = {};
-    Object.keys(results).forEach(function(eid) {
-      const result = results[eid];
-      genomeKeyStates.loaded.forEach(function(key) {
-        const active = !result.disabled.some(function(disabledKey) {
-          return strings.startsWith(key, disabledKey);
-        });
 
-        if (active) {
-          configKeyStates.active.add(key);
-          const entry = result.entry.some(function(entryKey) {
-            return strings.startsWith(key, entryKey);
-          });
+    const resultsMerged = Object.values(results).reduce((acc, result) => {
+      return {
+        disabled: [
+          ...acc.disabled,
+          ...result.disabled
+        ],
+        entry: [...acc.entry, ...result.entry]
+      }
+    }, { disabled: [], entry: []});
 
-          if (entry) {
-            configKeyStates.entry.add(key);
-          }
-        }
+    genomeKeyStates.loaded.forEach(function (key) {
+      const active = !resultsMerged.disabled.some(function (disabledKey) {
+        return strings.startsWith(key, disabledKey);
       });
 
+      if (active) {
+        configKeyStates.active.add(key);
+        const entry = resultsMerged.entry.some(function (entryKey) {
+          return strings.startsWith(key, entryKey);
+        });
+
+        if (entry) {
+          configKeyStates.entry.add(key);
+        }
+      }
+    });
+
+    Object.keys(results).forEach(function (eid) {
       if (eid in genomes) {
         effectiveGenome = objects.deepMerge(effectiveGenome, objects.filter(genomes[eid], configKeyStates.active));
       }

--- a/src/store.js
+++ b/src/store.js
@@ -187,13 +187,11 @@ function EvolvStore(options) {
     configKeyStates.entry.clear();
     effectiveGenome = {};
 
-    const resultsMerged = Object.values(results).reduce((acc, result) => {
+    const resultsMerged = Object.keys(results).reduce(function(acc, key){
+      const result = results[key];
       return {
-        disabled: [
-          ...acc.disabled,
-          ...result.disabled
-        ],
-        entry: [...acc.entry, ...result.entry]
+        disabled: acc.disabled.concat(result.disabled),
+        entry: acc.entry.concat(result.entry)
       }
     }, { disabled: [], entry: []});
 

--- a/src/tests/store.test.js
+++ b/src/tests/store.test.js
@@ -1,9 +1,12 @@
 import assert from 'assert';
+import chai from 'chai';
+
+const { expect } = chai;
 
 import base64 from '../ponyfills/base64.js';
 
 import Context from '../context.js';
-import Store, { evaluatePredicates } from '../store.js';
+import Store, { evaluatePredicates, getActiveAndEntryConfigKeyStates } from '../store.js';
 
 describe('store.js', () => {
   describe('evaluatePredicates', () => {
@@ -197,4 +200,48 @@ describe('store.js', () => {
       assert.ok(!rejected['0f39849197'].entry.length, 'No entry keys should have been found');
     });
   });
+
+  describe('getActiveAndEntryConfigKeyStates', () => {
+    it('should not add key if the key starts with strings in disabled array', () => {
+
+      const loadedKeyStates = new Set([
+        "web", 
+        "web.cwj1t5d3r", 
+        "web.cwj1t5d3r.3niwqixti", 
+        "web.cwj1t5d3r.3niwqixti.id", 
+        "web.cwj1t5d3r.3niwqixti.type",
+        "web.cwj1t5d3r.3niwqixti.script",
+        "web.cwj1t5d3r.3niwqixti.styles",
+        "web.20o82m2i2",
+        "web.20o82m2i2.i5vha3r5s",
+        "web.20o82m2i2.i5vha3r5s.id",
+        "web.20o82m2i2.i5vha3r5s.type",
+        "web.20o82m2i2.i5vha3r5s.script",
+        "web.20o82m2i2.i5vha3r5s.styles",
+        "web.234234gdfg.sdfsdf"
+      ])
+
+      const results = {
+        '10179f895b': {
+          disabled: ['web.cwj1t5d3r'],
+          entry: []
+        }, 
+        'e33daae52a': {
+          disabled: [
+            'web.20o82m2i2'
+          ],
+          entry: []
+        },
+        'whdjksjd': {
+          disabled: [
+            'web.234234gdfg'
+          ],
+          entry: []
+        }
+      };
+
+      const keys = getActiveAndEntryConfigKeyStates(results, loadedKeyStates);
+      expect(keys).to.deep.equal({ active: ['web'], entry: [] });
+    })
+  })
 });


### PR DESCRIPTION
before: 
![image](https://user-images.githubusercontent.com/1557388/90055222-b295ba80-dce5-11ea-8dc3-460ad5aa89cb.png)
after: 
![image](https://user-images.githubusercontent.com/1557388/90055390-f1c40b80-dce5-11ea-99b3-ca773ffb9334.png)

evolv.client.getActiveKeys() return key 'web', because there is no _predicate for this context, so no changes applied for it

Root case:
this bug was caused because of an incorrect check for active predicates. Function reevaluateContext did check in a loop if some string match regexp and added the active key to Map. The problem is that string can match regexp for one iteration and did not match for another, but it already added to Map as matched, so the solution is to combine all disabled contexts and do check with combined data.