### PR TITLE
fix: fire cofirm/contaminate events only for experiments with context…

### DIFF
--- a/src/tests/index.test.js
+++ b/src/tests/index.test.js
@@ -93,7 +93,7 @@ async function validateClient(evolv, options, uid, sid) {
   expect(await evolv.getConfig('web')).to.be.an('undefined');
   expect(await evolv.getConfig('web.ab8numq2j')).to.be.an('undefined');
   expect(await evolv.getConfig('web.ab8numq2j.am94yhwo2')).to.be.an('undefined');
-  expect(contextChangedSpy).to.have.been.called(4);
+  expect(contextChangedSpy).to.have.been.called(6);
 
   const valueWebKeySpy = chai.spy();
   const valueWebAb8numq2jKeySpy = chai.spy();
@@ -111,7 +111,7 @@ async function validateClient(evolv, options, uid, sid) {
   evolv.confirm();
 
   evolv.context.set('user_attributes.country', 'usa');
-  expect(contextChangedSpy).to.have.been.called(6);
+  expect(contextChangedSpy).to.have.been.called(8);
   expect(await evolv.isActive('web.ab8numq2j')).to.be.true;
   expect(await evolv.get('web.ab8numq2j.am94yhwo2.id')).to.equal('2fxe5dy5j');
   expect((await evolv.get('web.ab8numq2j.am94yhwo2')).id).to.equal('2fxe5dy5j');
@@ -147,7 +147,7 @@ async function validateClient(evolv, options, uid, sid) {
   evolv.getActiveKeys('nope').listen(noKeysSpy);
 
   evolv.context.set('web.url', 'https://www.lunch.com/dev1/features.html');
-  expect(contextChangedSpy).to.have.been.called(16);
+  expect(contextChangedSpy).to.have.been.called(11);
   expect(await evolv.isActive('web.ab8numq2j')).to.be.false;
   expect(await evolv.get('web.ab8numq2j.am94yhwo2')).to.be.an('undefined');
   expect(await evolv.isActive('web.7w3zpgfy9')).to.be.true;
@@ -163,7 +163,7 @@ async function validateClient(evolv, options, uid, sid) {
   evolv.confirm();
 
   evolv.context.remove('web.url');
-  expect(contextChangedSpy).to.have.been.called(22);
+  expect(contextChangedSpy).to.have.been.called(13);
   expect(await evolv.isActive('web.ab8numq2j')).to.be.false;
   expect(await evolv.get('web.ab8numq2j.am94yhwo2')).to.be.an('undefined');
   expect(await evolv.isActive('web.7w3zpgfy9')).to.be.false;
@@ -618,7 +618,7 @@ describe('Evolv client', () => {
       expect(results.analyticsPayloads.length).to.equal(1);
       expect(results.analyticsPayloads[0].uid).to.equal(uid);
       const messages = results.analyticsPayloads[0].messages
-      expect(messages.length).to.equal(22)
+      expect(messages.length).to.equal(13)
       expect(messages[0].type).to.equal("context.initialized")
       expect(messages[0].payload).to.eql( {
         "remote": true,
@@ -633,45 +633,53 @@ describe('Evolv client', () => {
       expect(messages[1].sid).to.equal(sid)
       expect(messages[2].type).to.equal("context.value.added")
       expect(messages[2].payload.key).to.equal("experiments.allocations")
-      expect(messages[2].payload.value).to.eql([{
+      expect(messages[2].payload.value).to.eql([]);
+      expect(messages[2].sid).to.equal(sid)
+      expect(messages[3].type).to.equal("context.value.changed")
+      expect(messages[3].payload.key).to.equal("experiments.allocations")
+      expect(messages[3].payload.value).to.eql([{
 				"uid": 123,
 				"sid": 321,
 				"eid": "0f39849197",
 				"cid": "0cf8ffcedea2:0f39849197",
 				"excluded": false
-			}])
-      expect(messages[2].sid).to.equal(sid)
-      expect(messages[3].type).to.equal("context.value.added")
-      expect(messages[3].payload.key).to.equal("experiments.exclusions")
-      expect(messages[3].payload.value).to.eql([])
+      }])
       expect(messages[3].sid).to.equal(sid)
-      expect(messages[4].type).to.equal("context.value.added")
-      expect(messages[4].payload.key).to.equal("user_attributes.country")
-      expect(messages[4].payload.value).to.equal("usa")
+      expect(messages[4].type).to.equal("context.value.changed")
+      expect(messages[4].payload.key).to.equal("experiments.allocations")
+      expect(messages[4].payload.value).to.eql([]);
       expect(messages[4].sid).to.equal(sid)
-      expect(messages[5].type).to.equal("context.value.changed")
-      expect(messages[5].payload.key).to.equal("keys.active")
-      expect(messages[5].payload.value).to.eql(["web", "web.ab8numq2j", "web.ab8numq2j.am94yhwo2", "web.ab8numq2j.am94yhwo2.id", "web.ab8numq2j.am94yhwo2.type", "web.ab8numq2j.am94yhwo2.script", "web.ab8numq2j.am94yhwo2.styles"])
+      expect(messages[5].type).to.equal("context.value.added")
+      expect(messages[5].payload.key).to.equal("experiments.exclusions")
+      expect(messages[5].payload.value).to.eql([])
       expect(messages[5].sid).to.equal(sid)
-      expect(messages[12].type).to.equal("context.value.added")
-      expect(messages[12].payload.key).to.equal("events")
-      expect(messages[12].payload.value[0].type).to.equal("lunch-time")
+      expect(messages[6].type).to.equal("context.value.added")
+      expect(messages[6].payload.key).to.equal("user_attributes.country")
+      expect(messages[6].payload.value).to.equal("usa")
+      expect(messages[6].sid).to.equal(sid)
+      expect(messages[7].type).to.equal("context.value.changed")
+      expect(messages[7].payload.key).to.equal("keys.active")
+      expect(messages[7].payload.value).to.eql(["web", "web.ab8numq2j", "web.ab8numq2j.am94yhwo2", "web.ab8numq2j.am94yhwo2.id", "web.ab8numq2j.am94yhwo2.type", "web.ab8numq2j.am94yhwo2.script", "web.ab8numq2j.am94yhwo2.styles"])
+      expect(messages[7].sid).to.equal(sid)
+      expect(messages[8].type).to.equal("context.value.added")
+      expect(messages[8].payload.key).to.equal("events")
+      expect(messages[8].payload.value[0].type).to.equal("lunch-time")
+      expect(messages[8].sid).to.equal(sid)
+      expect(messages[9].type).to.equal("context.value.changed")
+      expect(messages[9].payload.key).to.equal("web.url")
+      expect(messages[9].payload.value).to.equal("https://www.lunch.com/dev1/features.html")
+      expect(messages[9].sid).to.equal(sid)
+      expect(messages[10].type).to.equal("context.value.changed")
+      expect(messages[10].payload.key).to.equal("keys.active")
+      expect(messages[10].payload.value).to.eql(["web", "web.7w3zpgfy9", "web.7w3zpgfy9.azevlvf5g", "web.7w3zpgfy9.azevlvf5g.type"])
+      expect(messages[10].sid).to.equal(sid)
+      expect(messages[11].type).to.equal("context.value.removed")
+      expect(messages[11].payload.key).to.equal("web.url")
+      expect(messages[11].sid).to.equal(sid)
+      expect(messages[12].type).to.equal("context.value.changed")
+      expect(messages[12].payload.key).to.equal("keys.active")
+      expect(messages[12].payload.value).to.eql(['web'])
       expect(messages[12].sid).to.equal(sid)
-      expect(messages[14].type).to.equal("context.value.changed")
-      expect(messages[14].payload.key).to.equal("web.url")
-      expect(messages[14].payload.value).to.equal("https://www.lunch.com/dev1/features.html")
-      expect(messages[14].sid).to.equal(sid)
-      expect(messages[15].type).to.equal("context.value.changed")
-      expect(messages[15].payload.key).to.equal("keys.active")
-      expect(messages[15].payload.value).to.eql(["web", "web.7w3zpgfy9", "web.7w3zpgfy9.azevlvf5g", "web.7w3zpgfy9.azevlvf5g.type"])
-      expect(messages[15].sid).to.equal(sid)
-      expect(messages[20].type).to.equal("context.value.removed")
-      expect(messages[20].payload.key).to.equal("web.url")
-      expect(messages[20].sid).to.equal(sid)
-      expect(messages[21].type).to.equal("context.value.changed")
-      expect(messages[21].payload.key).to.equal("keys.active")
-      expect(messages[21].payload.value).to.eql(['web'])
-      expect(messages[21].sid).to.equal(sid)
     });
   });
 });


### PR DESCRIPTION
… match (#45)

* fix: fire cofirm/contaminate events only for experiments with context match

* fix: failing unit tests

Co-authored-by: Roman Mamchyk <rmamchyk@Romans-Mac-mini.local>