### PR TITLE
Fix/top level predicate

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -103,12 +103,20 @@ function EvolvClient(options) {
   /**
    * Preload all keys under under the specified prefixes.
    *
-   * @param {Array.<String>} prefixes A list of prefixes to keys to load.
-   * @param {Boolean} configOnly If true, only the config would be loaded. (default: false)
+   * @param {Map.<String, Array.<String>>} prefixes A map of experiment ids to prefixes to load.
    * @param {Boolean} immediate Forces the requests to the server. (default: false)
    * @method
    */
-  this.preload = store.preload.bind(store);
+  this.preloadConfig = store.preloadConfig.bind(store);
+
+  /**
+   * Preload all keys under under the specified prefixes.
+   *
+   * @param {Array.<String>} prefixes A list of prefixes to keys to load.
+   * @param {Boolean} immediate Forces the requests to the server. (default: false)
+   * @method
+   */
+  this.preloadGenome = store.preloadGenome.bind(store);
 
   /**
    * Get the value of a specified key.

--- a/src/store.js
+++ b/src/store.js
@@ -369,7 +369,7 @@ function EvolvStore(options) {
         configKeyStates.forEach(function(expKeyStates) {
           (expKeyStates.get('loaded') || new Set()).forEach(function(prefix) {
             if (strings.startsWith(promise.key, prefix)) {
-              configLoaded = true
+              configLoaded = true;
             }
           })
         })

--- a/src/tests/store.test.js
+++ b/src/tests/store.test.js
@@ -3,10 +3,8 @@ import chai from 'chai';
 
 const { expect } = chai;
 
-import base64 from '../ponyfills/base64.js';
-
 import Context from '../context.js';
-import Store, { evaluatePredicates, getActiveAndEntryConfigKeyStates } from '../store.js';
+import { evaluatePredicates, setActiveAndEntryKeyStates } from '../store.js';
 
 describe('store.js', () => {
   describe('evaluatePredicates', () => {
@@ -201,47 +199,140 @@ describe('store.js', () => {
     });
   });
 
-  describe('getActiveAndEntryConfigKeyStates', () => {
-    it('should not add key if the key starts with strings in disabled array', () => {
-
-      const loadedKeyStates = new Set([
-        "web", 
-        "web.cwj1t5d3r", 
-        "web.cwj1t5d3r.3niwqixti", 
-        "web.cwj1t5d3r.3niwqixti.id", 
-        "web.cwj1t5d3r.3niwqixti.type",
-        "web.cwj1t5d3r.3niwqixti.script",
-        "web.cwj1t5d3r.3niwqixti.styles",
-        "web.20o82m2i2",
-        "web.20o82m2i2.i5vha3r5s",
-        "web.20o82m2i2.i5vha3r5s.id",
-        "web.20o82m2i2.i5vha3r5s.type",
-        "web.20o82m2i2.i5vha3r5s.script",
-        "web.20o82m2i2.i5vha3r5s.styles",
-        "web.234234gdfg.sdfsdf"
-      ])
-
-      const results = {
-        '10179f895b': {
-          disabled: ['web.cwj1t5d3r'],
-          entry: []
-        }, 
-        'e33daae52a': {
-          disabled: [
-            'web.20o82m2i2'
-          ],
-          entry: []
+  describe('setActiveAndEntryKeyStates', () => {
+    it('frazer test', () => {
+      const config = {
+        "_published": 1597878596.6255178,
+        "_client": {
+          "browser": "chrome",
+          "device": "desktop",
+          "location": "US",
+          "platform": "macos"
         },
-        'whdjksjd': {
-          disabled: [
-            'web.234234gdfg'
-          ],
-          entry: []
+        "_experiments": [{
+          "web": {
+            "dependencies": "\n",
+            "2nsqubits": {
+              "_is_entry_point": true,
+              "_predicate": {
+                "combinator": "and",
+                "rules": [{
+                  "field": "web.url",
+                  "operator": "regex64_match",
+                  "value": "L2h0dHBzPzpcL1wvW14vXStcL2luZGV4XC5odG1sKD86JHxcP3wjKS9p"
+                }]
+              }
+            },
+            "fiddrbo15": {
+              "_is_entry_point": false,
+              "_predicate": {
+                "combinator": "and",
+                "rules": [{
+                  "field": "web.url",
+                  "operator": "regex64_match",
+                  "value": "L2h0dHBzPzpcL1wvW14vXStcL3Byb2R1Y3RcLmh0bWwoPzokfFw/fCMpL2k="
+                }]
+              }
+            },
+            "ooycjnptz": {
+              "_is_entry_point": false,
+              "_predicate": {
+                "combinator": "and",
+                "rules": [{
+                  "field": "web.url",
+                  "operator": "regex64_match",
+                  "value": "L2h0dHBzPzpcL1wvW14vXStcL3ByaWNpbmdcLmh0bWwoPzokfFw/fCMpL2k="
+                }]
+              }
+            },
+            "nt1g7tbs2": {
+              "_is_entry_point": false,
+              "_predicate": {
+                "combinator": "and",
+                "rules": [{
+                  "field": "web.url",
+                  "operator": "regex64_match",
+                  "value": "L2h0dHBzPzpcL1wvW14vXStcL2NoZWNrb3V0XC5odG1sKD86JHxcP3wjKS9p"
+                }]
+              }
+            }
+          },
+          "_predicate": {},
+          "id": "60f67d8648",
+          "_paused": false
+        }, {
+          "web": {
+            "dependencies": "\n",
+            "2nshubits": {
+              "_is_entry_point": true,
+              "_predicate": {
+                "combinator": "and",
+                "rules": [{
+                  "field": "web.url",
+                  "operator": "regex64_match",
+                  "value": "L2h0dHBzPzpcL1wvW14vXStcL2luZGV4XC5odG1sKD86JHxcP3wjKS9p"
+                }]
+              }
+            },
+            "fidcrbo15": {
+              "_is_entry_point": false,
+              "_predicate": {
+                "combinator": "and",
+                "rules": [{
+                  "field": "web.url",
+                  "operator": "regex64_match",
+                  "value": "L2h0dHBzPzpcL1wvW14vXStcL3Byb2R1Y3RcLmh0bWwoPzokfFw/fCMpL2k="
+                }]
+              }
+            },
+            "ooycjpptz": {
+              "_is_entry_point": false,
+              "_predicate": {
+                "combinator": "and",
+                "rules": [{
+                  "field": "web.url",
+                  "operator": "regex64_match",
+                  "value": "L2h0dHBzPzpcL1wvW14vXStcL3ByaWNpbmdcLmh0bWwoPzokfFw/fCMpL2k="
+                }]
+              }
+            },
+            "nt1g7tfs2": {
+              "_is_entry_point": false,
+              "_predicate": {
+                "combinator": "and",
+                "rules": [{
+                  "field": "web.url",
+                  "operator": "regex64_match",
+                  "value": "L2h0dHBzPzpcL1wvW14vXStcL2NoZWNrb3V0XC5odG1sKD86JHxcP3wjKS9p"
+                }]
+              }
+            }
+          },
+          "_predicate": {
+            "id": 1,
+            "combinator": "and",
+            "rules": [{
+              "field": "device",
+              "operator": "equal",
+              "value": "mobile"
+            }]
+          },
+          "id": "64928df20a",
+          "_paused": false
+        }]
+      }
+      const context = new Context();
+      context.initialize(123, 321, {
+        web: {
+          url: 'https://test.site.com/index.html'
         }
-      };
+      });
+      const configKeyStates = new Map();
+      const genomeConfigKeyStates = { loaded: new Set(["web","web.2nsqubits","web.2nsqubits.p99utjadn","web.2nsqubits.p99utjadn.id","web.2nsqubits.p99utjadn.type","web.2nsqubits.p99utjadn.script","web.2nsqubits.p99utjadn.styles","web.2nsqubits.u4mehfi0j","web.2nsqubits.u4mehfi0j.type","web.fiddrbo15","web.fiddrbo15.ma3mr8iy6","web.fiddrbo15.ma3mr8iy6.type","web.ooycjnptz","web.ooycjnptz.lo7yrjkkg","web.ooycjnptz.lo7yrjkkg.type","web.nt1g7tbs2","web.nt1g7tbs2.vzyq1yz56","web.nt1g7tbs2.vzyq1yz56.type","web.2nshubits","web.2nshubits.p89utjadn","web.2nshubits.p89utjadn.id","web.2nshubits.p89utjadn.type","web.2nshubits.p89utjadn.script","web.2nshubits.p89utjadn.styles","web.2nshubits.u4nehfi0j","web.2nshubits.u4nehfi0j.type","web.fidcrbo15","web.fidcrbo15.ma9mr8iy6","web.fidcrbo15.ma9mr8iy6.type","web.ooycjpptz","web.ooycjpptz.lo7yrjkkg","web.ooycjpptz.lo7yrjkkg.type","web.nt1g7tfs2","web.nt1g7tfs2.vzyq1yz56","web.nt1g7tfs2.vzyq1yz56.type"]) };
 
-      const keys = getActiveAndEntryConfigKeyStates(results, loadedKeyStates);
-      expect(keys).to.deep.equal({ active: ['web'], entry: [] });
-    })
-  })
+      const result = setActiveAndEntryKeyStates(1, context, config, configKeyStates, genomeConfigKeyStates)
+
+      console.log(result);
+    });
+  });
 });

--- a/src/tests/store.test.js
+++ b/src/tests/store.test.js
@@ -4,7 +4,7 @@ import chai from 'chai';
 const { expect } = chai;
 
 import Context from '../context.js';
-import { evaluatePredicates, setActiveAndEntryKeyStates } from '../store.js';
+import { evaluatePredicates, setActiveAndEntryKeyStates, generateEffectiveGenome } from '../store.js';
 
 describe('store.js', () => {
   describe('evaluatePredicates', () => {
@@ -200,7 +200,7 @@ describe('store.js', () => {
   });
 
   describe('setActiveAndEntryKeyStates', () => {
-    it('frazer test', () => {
+    it('should produce the correct active and entry keys per experiment', () => {
       const config = {
         "_published": 1597878596.6255178,
         "_client": {
@@ -332,7 +332,282 @@ describe('store.js', () => {
 
       const result = setActiveAndEntryKeyStates(1, context, config, configKeyStates, genomeConfigKeyStates)
 
-      console.log(result);
+      expect(result.size).to.be.equal(2)
+      expect(result.has('60f67d8648')).to.be.true
+      expect(result.get('60f67d8648').has('active')).to.be.true
+      expect(Array.from(result.get('60f67d8648').get('active'))).to.be.eql(["web","web.2nsqubits","web.2nsqubits.p99utjadn","web.2nsqubits.p99utjadn.id","web.2nsqubits.p99utjadn.type","web.2nsqubits.p99utjadn.script","web.2nsqubits.p99utjadn.styles","web.2nsqubits.u4mehfi0j","web.2nsqubits.u4mehfi0j.type","web.2nshubits","web.2nshubits.p89utjadn","web.2nshubits.p89utjadn.id","web.2nshubits.p89utjadn.type","web.2nshubits.p89utjadn.script","web.2nshubits.p89utjadn.styles","web.2nshubits.u4nehfi0j","web.2nshubits.u4nehfi0j.type","web.fidcrbo15","web.fidcrbo15.ma9mr8iy6","web.fidcrbo15.ma9mr8iy6.type","web.ooycjpptz","web.ooycjpptz.lo7yrjkkg","web.ooycjpptz.lo7yrjkkg.type","web.nt1g7tfs2","web.nt1g7tfs2.vzyq1yz56","web.nt1g7tfs2.vzyq1yz56.type"])
+      expect(result.get('60f67d8648').has('entry')).to.be.true
+      expect(Array.from(result.get('60f67d8648').get('entry'))).to.be.eql(["web.2nsqubits", "web.2nsqubits.p99utjadn", "web.2nsqubits.p99utjadn.id", "web.2nsqubits.p99utjadn.type", "web.2nsqubits.p99utjadn.script", "web.2nsqubits.p99utjadn.styles", "web.2nsqubits.u4mehfi0j", "web.2nsqubits.u4mehfi0j.type"])
+      expect(result.has('64928df20a')).to.be.true
+      expect(result.get('64928df20a').has('active')).to.be.true
+      expect(Array.from(result.get('64928df20a').get('active'))).to.be.eql([])
+      expect(result.get('64928df20a').has('entry')).to.be.true
+      expect(Array.from(result.get('64928df20a').get('entry'))).to.be.eql([])
+    });
+  });
+
+  describe('generateEffectiveGenome', () => {
+    let config;
+    let genomes;
+    let context;
+    let configKeyStates;
+    let genomeConfigKeyStates;
+    beforeEach(() => {
+      config = {
+        "_published": 1597878596.6255178,
+        "_client": {
+          "browser": "chrome",
+          "device": "desktop",
+          "location": "US",
+          "platform": "macos"
+        },
+        "_experiments": [{
+          "web": {
+            "dependencies": "\n",
+            "2nsqubits": {
+              "_is_entry_point": true,
+              "_predicate": {
+                "combinator": "and",
+                "rules": [{
+                  "field": "web.url",
+                  "operator": "regex64_match",
+                  "value": "L2h0dHBzPzpcL1wvW14vXStcL2luZGV4XC5odG1sKD86JHxcP3wjKS9p"
+                }]
+              }
+            },
+            "fiddrbo15": {
+              "_is_entry_point": false,
+              "_predicate": {
+                "combinator": "and",
+                "rules": [{
+                  "field": "web.url",
+                  "operator": "regex64_match",
+                  "value": "L2h0dHBzPzpcL1wvW14vXStcL3Byb2R1Y3RcLmh0bWwoPzokfFw/fCMpL2k="
+                }]
+              }
+            },
+            "ooycjnptz": {
+              "_is_entry_point": false,
+              "_predicate": {
+                "combinator": "and",
+                "rules": [{
+                  "field": "web.url",
+                  "operator": "regex64_match",
+                  "value": "L2h0dHBzPzpcL1wvW14vXStcL3ByaWNpbmdcLmh0bWwoPzokfFw/fCMpL2k="
+                }]
+              }
+            },
+            "nt1g7tbs2": {
+              "_is_entry_point": false,
+              "_predicate": {
+                "combinator": "and",
+                "rules": [{
+                  "field": "web.url",
+                  "operator": "regex64_match",
+                  "value": "L2h0dHBzPzpcL1wvW14vXStcL2NoZWNrb3V0XC5odG1sKD86JHxcP3wjKS9p"
+                }]
+              }
+            }
+          },
+          "_predicate": {},
+          "id": "60f67d8648",
+          "_paused": false
+        }, {
+          "web": {
+            "dependencies": "\n",
+            "2nshubits": {
+              "_is_entry_point": true,
+              "_predicate": {
+                "combinator": "and",
+                "rules": [{
+                  "field": "web.url",
+                  "operator": "regex64_match",
+                  "value": "L2h0dHBzPzpcL1wvW14vXStcL2luZGV4XC5odG1sKD86JHxcP3wjKS9p"
+                }]
+              }
+            },
+            "fidcrbo15": {
+              "_is_entry_point": false,
+              "_predicate": {
+                "combinator": "and",
+                "rules": [{
+                  "field": "web.url",
+                  "operator": "regex64_match",
+                  "value": "L2h0dHBzPzpcL1wvW14vXStcL3Byb2R1Y3RcLmh0bWwoPzokfFw/fCMpL2k="
+                }]
+              }
+            },
+            "ooycjpptz": {
+              "_is_entry_point": false,
+              "_predicate": {
+                "combinator": "and",
+                "rules": [{
+                  "field": "web.url",
+                  "operator": "regex64_match",
+                  "value": "L2h0dHBzPzpcL1wvW14vXStcL3ByaWNpbmdcLmh0bWwoPzokfFw/fCMpL2k="
+                }]
+              }
+            },
+            "nt1g7tfs2": {
+              "_is_entry_point": false,
+              "_predicate": {
+                "combinator": "and",
+                "rules": [{
+                  "field": "web.url",
+                  "operator": "regex64_match",
+                  "value": "L2h0dHBzPzpcL1wvW14vXStcL2NoZWNrb3V0XC5odG1sKD86JHxcP3wjKS9p"
+                }]
+              }
+            }
+          },
+          "_predicate": {
+            "id": 1,
+            "combinator": "and",
+            "rules": [{
+              "field": "device",
+              "operator": "equal",
+              "value": "mobile"
+            }]
+          },
+          "id": "64928df20a",
+          "_paused": false
+        }]
+      }
+      genomes = {
+        "60f67d8648": {
+          "web": {
+            "2nsqubits": {
+              "p99utjadn": {
+                "id": "tifv3fu1g",
+                "type": "compound",
+                "_metadata": {},
+                "script": "",
+                "styles": "a#learn.btn.btn-primary.btn-lg {\n  background-color: yellow\n}"
+              },
+              "u4mehfi0j": {
+                "type": "noop"
+              }
+            },
+            "fiddrbo15": {
+              "ma3mr8iy6": {
+                "type": "noop"
+              }
+            },
+            "ooycjnptz": {
+              "lo7yrjkkg": {
+                "type": "noop"
+              }
+            },
+            "nt1g7tbs2": {
+              "vzyq1yz56": {
+                "type": "noop"
+              }
+            }
+          }
+        },
+        "64928df20a": {
+          "web": {
+            "2nshubits": {
+              "p89utjadn": {
+                "id": "tift3fu1g",
+                "type": "compound",
+                "_metadata": {},
+                "script": "",
+                "styles": "a#learn.btn.btn-primary.btn-lg {\n  background-color: yellow\n}"
+              },
+              "u4nehfi0j": {
+                "type": "noop"
+              }
+            },
+            "fidcrbo15": {
+              "ma9mr8iy6": {
+                "type": "noop"
+              }
+            },
+            "ooycjpptz": {
+              "lo7yrjkkg": {
+                "type": "noop"
+              }
+            },
+            "nt1g7tfs2": {
+              "vzyq1yz56": {
+                "type": "noop"
+              }
+            }
+          }
+        }
+      }
+      context = new Context();
+      configKeyStates = new Map();
+      genomeConfigKeyStates = { loaded: new Set(["web","web.2nsqubits","web.2nsqubits.p99utjadn","web.2nsqubits.p99utjadn.id","web.2nsqubits.p99utjadn.type","web.2nsqubits.p99utjadn.script","web.2nsqubits.p99utjadn.styles","web.2nsqubits.u4mehfi0j","web.2nsqubits.u4mehfi0j.type","web.fiddrbo15","web.fiddrbo15.ma3mr8iy6","web.fiddrbo15.ma3mr8iy6.type","web.ooycjnptz","web.ooycjnptz.lo7yrjkkg","web.ooycjnptz.lo7yrjkkg.type","web.nt1g7tbs2","web.nt1g7tbs2.vzyq1yz56","web.nt1g7tbs2.vzyq1yz56.type","web.2nshubits","web.2nshubits.p89utjadn","web.2nshubits.p89utjadn.id","web.2nshubits.p89utjadn.type","web.2nshubits.p89utjadn.script","web.2nshubits.p89utjadn.styles","web.2nshubits.u4nehfi0j","web.2nshubits.u4nehfi0j.type","web.fidcrbo15","web.fidcrbo15.ma9mr8iy6","web.fidcrbo15.ma9mr8iy6.type","web.ooycjpptz","web.ooycjpptz.lo7yrjkkg","web.ooycjpptz.lo7yrjkkg.type","web.nt1g7tfs2","web.nt1g7tfs2.vzyq1yz56","web.nt1g7tfs2.vzyq1yz56.type"]) };
+    })
+
+    it('should generate genome for one experiment of two in same environment', () => {
+      context.initialize(123, 321, {
+        web: {
+          url: 'https://test.site.com/index.html'
+        }
+      });
+      configKeyStates = setActiveAndEntryKeyStates(1, context, config, configKeyStates, genomeConfigKeyStates);
+
+      const result = generateEffectiveGenome(configKeyStates, genomes);
+
+      expect(Array.from(result.activeEids)).to.be.eql(["60f67d8648"])
+      expect(result.effectiveGenome).to.be.eql({
+        "web": {
+          "2nsqubits": {
+            "p99utjadn": {
+              "id": "tifv3fu1g",
+              "type": "compound",
+              "script": "",
+              "styles": "a#learn.btn.btn-primary.btn-lg {\n  background-color: yellow\n}"
+            },
+            "u4mehfi0j": {
+              "type": "noop"
+            }
+          }
+        }
+      })
+    });
+
+    it('should generate genome for two experiments of two in same environment', () => {
+      context.initialize(123, 321, {
+        web: {
+          url: 'https://test.site.com/index.html'
+        },
+        device: 'mobile'
+      });
+      configKeyStates = setActiveAndEntryKeyStates(1, context, config, configKeyStates, genomeConfigKeyStates);
+
+      const result = generateEffectiveGenome(configKeyStates, genomes);
+
+      expect(Array.from(result.activeEids)).to.be.eql(["60f67d8648", "64928df20a"])
+      expect(result.effectiveGenome).to.be.eql({
+        "web": {
+          "2nsqubits": {
+            "p99utjadn": {
+              "id": "tifv3fu1g",
+              "type": "compound",
+              "script": "",
+              "styles": "a#learn.btn.btn-primary.btn-lg {\n  background-color: yellow\n}"
+            },
+            "u4mehfi0j": {
+              "type": "noop"
+            }
+          },
+          "2nshubits": {
+            "p89utjadn": {
+              "id": "tift3fu1g",
+              "type": "compound",
+              "script": "",
+              "styles": "a#learn.btn.btn-primary.btn-lg {\n  background-color: yellow\n}"
+            },
+            "u4nehfi0j": {
+              "type": "noop"
+            }
+          }
+        }
+      })
     });
   });
 });


### PR DESCRIPTION
Js SDK was not handling top level predicates correctly. When two or more experiments were live in an environment a top level predicate would nullify all of the experiments treatments even if they were valid. Fix stores all keys by eid to separate the experiment predicates. Change was quite pervasive throughout the store.