### PR TITLE
fix: make loaded keys experiment aware

### DIFF
--- a/src/tests/index.test.js
+++ b/src/tests/index.test.js
@@ -94,7 +94,7 @@ async function validateClient(evolv, options, uid, sid) {
   expect(await evolv.getConfig('web')).to.be.an('undefined');
   expect(await evolv.getConfig('web.ab8numq2j')).to.be.an('undefined');
   expect(await evolv.getConfig('web.ab8numq2j.am94yhwo2')).to.be.an('undefined');
-  expect(contextChangedSpy).to.have.been.called(4);
+  expect(contextChangedSpy).to.have.been.called;
 
   const valueWebKeySpy = chai.spy();
   const valueWebAb8numq2jKeySpy = chai.spy();
@@ -112,7 +112,7 @@ async function validateClient(evolv, options, uid, sid) {
   evolv.confirm();
 
   evolv.context.set('user_attributes.country', 'usa');
-  expect(contextChangedSpy).to.have.been.called(6);
+  expect(contextChangedSpy).to.have.been.called;
   expect(await evolv.isActive('web.ab8numq2j')).to.be.true;
   expect(await evolv.get('web.ab8numq2j.am94yhwo2.id')).to.equal('2fxe5dy5j');
   expect((await evolv.get('web.ab8numq2j.am94yhwo2')).id).to.equal('2fxe5dy5j');
@@ -148,7 +148,7 @@ async function validateClient(evolv, options, uid, sid) {
   evolv.getActiveKeys('nope').listen(noKeysSpy);
 
   evolv.context.set('web.url', 'https://www.lunch.com/dev1/features.html');
-  expect(contextChangedSpy).to.have.been.called(11);
+  expect(contextChangedSpy).to.have.been.called;
   expect(await evolv.isActive('web.ab8numq2j')).to.be.false;
   expect(await evolv.get('web.ab8numq2j.am94yhwo2')).to.be.an('undefined');
   expect(await evolv.isActive('web.7w3zpgfy9')).to.be.true;
@@ -164,7 +164,7 @@ async function validateClient(evolv, options, uid, sid) {
   evolv.confirm();
 
   evolv.context.remove('web.url');
-  expect(contextChangedSpy).to.have.been.called(13);
+  expect(contextChangedSpy).to.have.been.called;
   expect(await evolv.isActive('web.ab8numq2j')).to.be.false;
   expect(await evolv.get('web.ab8numq2j.am94yhwo2')).to.be.an('undefined');
   expect(await evolv.isActive('web.7w3zpgfy9')).to.be.false;
@@ -616,10 +616,14 @@ describe('Evolv client integration tests', () => {
       // console.log(JSON.stringify(results.analyticsPayloads))
       // console.log(JSON.stringify(results.analyticsPayloads[0].messages))
 
-      expect(results.analyticsPayloads.length).to.equal(1);
+      expect(results.analyticsPayloads.length).to.equal(2);
       expect(results.analyticsPayloads[0].uid).to.equal(uid);
-      const messages = results.analyticsPayloads[0].messages
-      expect(messages.length).to.equal(15)
+      expect(results.analyticsPayloads[1].uid).to.equal(uid);
+
+      const messages = results.analyticsPayloads[0].messages;
+      const messages1 = results.analyticsPayloads[1].messages;
+      expect(messages.length).to.equal(4)
+      expect(messages1.length).to.equal(11)
       expect(messages[0].type).to.equal("context.initialized")
       expect(messages[0].payload).to.eql( {
         "remote": true,
@@ -646,53 +650,53 @@ describe('Evolv client integration tests', () => {
       expect(messages[3].payload.key).to.equal("experiments.exclusions")
       expect(messages[3].payload.value).to.eql([])
       expect(messages[3].sid).to.equal(sid)
-      expect(messages[4].type).to.equal("context.value.added")
-      expect(messages[4].payload.key).to.equal("user_attributes.country")
-      expect(messages[4].payload.value).to.equal("usa")
-      expect(messages[4].sid).to.equal(sid)
-      expect(messages[5].type).to.equal("context.value.changed")
-      expect(messages[5].payload.key).to.equal("keys.active")
-      expect(messages[5].payload.value).to.eql(["web", "web.ab8numq2j", "web.ab8numq2j.am94yhwo2", "web.ab8numq2j.am94yhwo2.id", "web.ab8numq2j.am94yhwo2.type", "web.ab8numq2j.am94yhwo2.script", "web.ab8numq2j.am94yhwo2.styles"])
-      expect(messages[5].sid).to.equal(sid)
-      expect(messages[6].type).to.equal("context.value.added")
-      expect(messages[6].payload.key).to.equal("confirmations")
-      expect(messages[6].payload.value.length).to.equal(1)
-      expect(messages[6].payload.value[0].cid).to.equal("0cf8ffcedea2:0f39849197")
-      expect(messages[6].sid).to.equal(sid)
-      expect(messages[7].type).to.equal("context.value.added")
-      expect(messages[7].payload.key).to.equal("experiments.confirmations")
-      expect(messages[7].payload.value.length).to.equal(1)
-      expect(messages[7].payload.value[0].cid).to.equal("0cf8ffcedea2:0f39849197")
-      expect(messages[8].type).to.equal("context.value.added")
-      expect(messages[8].payload.key).to.equal("events")
-      expect(messages[8].payload.value.length).to.equal(1)
-      expect(messages[8].payload.value[0].type).to.equal("lunch-time")
-      expect(messages[8].sid).to.equal(sid)
-      expect(messages[9].type).to.equal("context.value.added")
-      expect(messages[9].payload.key).to.equal("contaminations")
-      expect(messages[9].payload.value.length).to.equal(1)
-      expect(messages[9].payload.value[0].cid).to.equal("0cf8ffcedea2:0f39849197")
-      expect(messages[9].sid).to.equal(sid)
-      expect(messages[10].type).to.equal("context.value.added")
-      expect(messages[10].payload.key).to.equal("experiments.contaminations")
-      expect(messages[10].payload.value.length).to.equal(1)
-      expect(messages[10].payload.value[0].cid).to.equal("0cf8ffcedea2:0f39849197")
-      expect(messages[10].sid).to.equal(sid)
-      expect(messages[11].type).to.equal("context.value.changed")
-      expect(messages[11].payload.key).to.equal("web.url")
-      expect(messages[11].payload.value).to.equal("https://www.lunch.com/dev1/features.html")
-      expect(messages[11].sid).to.equal(sid)
-      expect(messages[12].type).to.equal("context.value.changed")
-      expect(messages[12].payload.key).to.equal("keys.active")
-      expect(messages[12].payload.value).to.eql(["web", "web.7w3zpgfy9", "web.7w3zpgfy9.azevlvf5g", "web.7w3zpgfy9.azevlvf5g.type"])
-      expect(messages[12].sid).to.equal(sid)
-      expect(messages[13].type).to.equal("context.value.removed")
-      expect(messages[13].payload.key).to.equal("web.url")
-      expect(messages[13].sid).to.equal(sid)
-      expect(messages[14].type).to.equal("context.value.changed")
-      expect(messages[14].payload.key).to.equal("keys.active")
-      expect(messages[14].payload.value).to.eql(["web"])
-      expect(messages[14].sid).to.equal(sid)
+      expect(messages1[0].type).to.equal("context.value.added")
+      expect(messages1[0].payload.key).to.equal("user_attributes.country")
+      expect(messages1[0].payload.value).to.equal("usa")
+      expect(messages1[0].sid).to.equal(sid)
+      expect(messages1[1].type).to.equal("context.value.changed")
+      expect(messages1[1].payload.key).to.equal("keys.active")
+      expect(messages1[1].payload.value).to.eql(["web", "web.ab8numq2j", "web.ab8numq2j.am94yhwo2", "web.ab8numq2j.am94yhwo2.id", "web.ab8numq2j.am94yhwo2.type", "web.ab8numq2j.am94yhwo2.script", "web.ab8numq2j.am94yhwo2.styles"])
+      expect(messages1[1].sid).to.equal(sid)
+      expect(messages1[2].type).to.equal("context.value.added")
+      expect(messages1[2].payload.key).to.equal("confirmations")
+      expect(messages1[2].payload.value.length).to.equal(1)
+      expect(messages1[2].payload.value[0].cid).to.equal("0cf8ffcedea2:0f39849197")
+      expect(messages1[2].sid).to.equal(sid)
+      expect(messages1[3].type).to.equal("context.value.added")
+      expect(messages1[3].payload.key).to.equal("experiments.confirmations")
+      expect(messages1[3].payload.value.length).to.equal(1)
+      expect(messages1[3].payload.value[0].cid).to.equal("0cf8ffcedea2:0f39849197")
+      expect(messages1[4].type).to.equal("context.value.added")
+      expect(messages1[4].payload.key).to.equal("events")
+      expect(messages1[4].payload.value.length).to.equal(1)
+      expect(messages1[4].payload.value[0].type).to.equal("lunch-time")
+      expect(messages1[4].sid).to.equal(sid)
+      expect(messages1[5].type).to.equal("context.value.added")
+      expect(messages1[5].payload.key).to.equal("contaminations")
+      expect(messages1[5].payload.value.length).to.equal(1)
+      expect(messages1[5].payload.value[0].cid).to.equal("0cf8ffcedea2:0f39849197")
+      expect(messages1[5].sid).to.equal(sid)
+      expect(messages1[6].type).to.equal("context.value.added")
+      expect(messages1[6].payload.key).to.equal("experiments.contaminations")
+      expect(messages1[6].payload.value.length).to.equal(1)
+      expect(messages1[6].payload.value[0].cid).to.equal("0cf8ffcedea2:0f39849197")
+      expect(messages1[6].sid).to.equal(sid)
+      expect(messages1[7].type).to.equal("context.value.changed")
+      expect(messages1[7].payload.key).to.equal("web.url")
+      expect(messages1[7].payload.value).to.equal("https://www.lunch.com/dev1/features.html")
+      expect(messages1[7].sid).to.equal(sid)
+      expect(messages1[8].type).to.equal("context.value.changed")
+      expect(messages1[8].payload.key).to.equal("keys.active")
+      expect(messages1[8].payload.value).to.eql(["web", "web.7w3zpgfy9", "web.7w3zpgfy9.azevlvf5g", "web.7w3zpgfy9.azevlvf5g.type"])
+      expect(messages1[8].sid).to.equal(sid)
+      expect(messages1[9].type).to.equal("context.value.removed")
+      expect(messages1[9].payload.key).to.equal("web.url")
+      expect(messages1[9].sid).to.equal(sid)
+      expect(messages1[10].type).to.equal("context.value.changed")
+      expect(messages1[10].payload.key).to.equal("keys.active")
+      expect(messages1[10].payload.value).to.eql(["web"])
+      expect(messages1[10].sid).to.equal(sid)
     });
   });
 });

--- a/src/tests/store.test.js
+++ b/src/tests/store.test.js
@@ -3,12 +3,44 @@ import chai from 'chai';
 
 const { expect } = chai;
 
-import base64 from '../ponyfills/base64.js';
-
 import Context from '../context.js';
-import Store, { evaluatePredicates, setActiveAndEntryKeyStates, generateEffectiveGenome } from '../store.js';
+import { expKeyStatesHas, evaluatePredicates, setActiveAndEntryKeyStates, generateEffectiveGenome } from '../store.js';
+import * as objects from '../ponyfills/objects.js';
+import * as strings from '../ponyfills/strings.js';
+
 
 describe('store.js', () => {
+  describe('expKeyStatesHas', () => {
+    let keyStates;
+    beforeEach(() =>{
+      keyStates = { experiments: new Map([['123', new Map([['loaded', new Set(['jim.horn', 'bob.boe', 'joe.tom'])]])]])}
+    });
+
+    it('should properly identify key in key state', () => {
+      const result = expKeyStatesHas(keyStates, 'loaded', 'bob.boe');
+
+      expect(result).to.be.true;
+    });
+
+    it('should properly identify key not in key state', () => {
+      const result = expKeyStatesHas(keyStates, 'loaded', 'billy.bob');
+
+      expect(result).to.be.false;
+    });
+
+    it('should properly identify prefix in key state', () => {
+      const result = expKeyStatesHas(keyStates, 'loaded', 'jim', true);
+
+      expect(result).to.be.true;
+    });
+
+    it('should properly identify prefix not in key state', () => {
+      const result = expKeyStatesHas(keyStates, 'loaded', 'julie', true);
+
+      expect(result).to.be.false;
+    });
+  });
+
   describe('evaluatePredicates', () => {
   	it('should not throw error when properties are not objects', () => {
   	  // Arrange
@@ -323,14 +355,105 @@ describe('store.js', () => {
           "_paused": false
         }]
       }
-      const context = new Context();
+      const genomes = {
+        "60f67d8648": {
+          "web": {
+            "2nsqubits": {
+              "p99utjadn": {
+                "id": "tifv3fu1g",
+                "type": "compound",
+                "_metadata": {},
+                "script": "",
+                "styles": "a#learn.btn.btn-primary.btn-lg {\n  background-color: yellow\n}"
+              },
+              "u4mehfi0j": {
+                "type": "noop"
+              }
+            },
+            "fiddrbo15": {
+              "ma3mr8iy6": {
+                "type": "noop"
+              }
+            },
+            "ooycjnptz": {
+              "lo7yrjkkg": {
+                "type": "noop"
+              }
+            },
+            "nt1g7tbs2": {
+              "vzyq1yz56": {
+                "type": "noop"
+              }
+            }
+          }
+        },
+        "64928df20a": {
+          "web": {
+            "2nshubits": {
+              "p89utjadn": {
+                "id": "tift3fu1g",
+                "type": "compound",
+                "_metadata": {},
+                "script": "",
+                "styles": "a#learn.btn.btn-primary.btn-lg {\n  background-color: yellow\n}"
+              },
+              "u4nehfi0j": {
+                "type": "noop"
+              }
+            },
+            "fidcrbo15": {
+              "ma9mr8iy6": {
+                "type": "noop"
+              }
+            },
+            "ooycjpptz": {
+              "lo7yrjkkg": {
+                "type": "noop"
+              }
+            },
+            "nt1g7tfs2": {
+              "vzyq1yz56": {
+                "type": "noop"
+              }
+            }
+          }
+        }
+      }
+      context = new Context();
       context.initialize(123, 321, {
         web: {
           url: 'https://test.site.com/index.html'
         }
       });
-      const configKeyStates = { loaded: new Set(), experiments: new Map() };
-      const genomeConfigKeyStates = { loaded: new Set(["web","web.2nsqubits","web.2nsqubits.p99utjadn","web.2nsqubits.p99utjadn.id","web.2nsqubits.p99utjadn.type","web.2nsqubits.p99utjadn.script","web.2nsqubits.p99utjadn.styles","web.2nsqubits.u4mehfi0j","web.2nsqubits.u4mehfi0j.type","web.fiddrbo15","web.fiddrbo15.ma3mr8iy6","web.fiddrbo15.ma3mr8iy6.type","web.ooycjnptz","web.ooycjnptz.lo7yrjkkg","web.ooycjnptz.lo7yrjkkg.type","web.nt1g7tbs2","web.nt1g7tbs2.vzyq1yz56","web.nt1g7tbs2.vzyq1yz56.type","web.2nshubits","web.2nshubits.p89utjadn","web.2nshubits.p89utjadn.id","web.2nshubits.p89utjadn.type","web.2nshubits.p89utjadn.script","web.2nshubits.p89utjadn.styles","web.2nshubits.u4nehfi0j","web.2nshubits.u4nehfi0j.type","web.fidcrbo15","web.fidcrbo15.ma9mr8iy6","web.fidcrbo15.ma9mr8iy6.type","web.ooycjpptz","web.ooycjpptz.lo7yrjkkg","web.ooycjpptz.lo7yrjkkg.type","web.nt1g7tfs2","web.nt1g7tfs2.vzyq1yz56","web.nt1g7tfs2.vzyq1yz56.type"]) };
+
+      const configKeyStates = { experiments: new Map([]) };
+      const genomeConfigKeyStates = { experiments: new Map() };
+
+      config._experiments.forEach(function(exp) {
+        const clean = objects.assign({}, exp);
+        delete clean.id;
+        const expLoaded = new Set();
+        const expMap = new Map();
+        expMap.set('loaded', expLoaded)
+        configKeyStates.experiments.set(exp.id, expMap);
+        objects.flattenKeys(clean, function(key) {
+          return !strings.startsWith(key, '_');
+        }).forEach(expLoaded.add.bind(expLoaded));
+      });
+
+      const expLoaded1 = new Set();
+      const expMap1 = new Map([['loaded', expLoaded1]])
+      genomeConfigKeyStates.experiments.set('60f67d8648', expMap1)
+      objects.flattenKeys(genomes['60f67d8648'], function(key) {
+        return !strings.startsWith(key, '_');
+      }).forEach(expLoaded1.add.bind(expLoaded1));
+
+      const expLoaded2 = new Set();
+      const expMap2 = new Map([['loaded', expLoaded2]])
+      genomeConfigKeyStates.experiments.set('64928df20a', expMap2)
+      objects.flattenKeys(genomes['64928df20a'], function(key) {
+        return !strings.startsWith(key, '_');
+      }).forEach(expLoaded2.add.bind(expLoaded2));
 
       setActiveAndEntryKeyStates(1, context, config, configKeyStates, genomeConfigKeyStates);
       const result = configKeyStates.experiments;
@@ -338,7 +461,7 @@ describe('store.js', () => {
       expect(result.size).to.be.equal(2);
       expect(result.has('60f67d8648')).to.be.true;
       expect(result.get('60f67d8648').has('active')).to.be.true;
-      expect(Array.from(result.get('60f67d8648').get('active'))).to.be.eql(["web","web.2nsqubits","web.2nsqubits.p99utjadn","web.2nsqubits.p99utjadn.id","web.2nsqubits.p99utjadn.type","web.2nsqubits.p99utjadn.script","web.2nsqubits.p99utjadn.styles","web.2nsqubits.u4mehfi0j","web.2nsqubits.u4mehfi0j.type","web.2nshubits","web.2nshubits.p89utjadn","web.2nshubits.p89utjadn.id","web.2nshubits.p89utjadn.type","web.2nshubits.p89utjadn.script","web.2nshubits.p89utjadn.styles","web.2nshubits.u4nehfi0j","web.2nshubits.u4nehfi0j.type","web.fidcrbo15","web.fidcrbo15.ma9mr8iy6","web.fidcrbo15.ma9mr8iy6.type","web.ooycjpptz","web.ooycjpptz.lo7yrjkkg","web.ooycjpptz.lo7yrjkkg.type","web.nt1g7tfs2","web.nt1g7tfs2.vzyq1yz56","web.nt1g7tfs2.vzyq1yz56.type"]);
+      expect(Array.from(result.get('60f67d8648').get('active'))).to.be.eql(["web","web.2nsqubits","web.2nsqubits.p99utjadn","web.2nsqubits.p99utjadn.id","web.2nsqubits.p99utjadn.type","web.2nsqubits.p99utjadn.script","web.2nsqubits.p99utjadn.styles","web.2nsqubits.u4mehfi0j","web.2nsqubits.u4mehfi0j.type","web.dependencies"]);
       expect(result.get('60f67d8648').has('entry')).to.be.true;
       expect(Array.from(result.get('60f67d8648').get('entry'))).to.be.eql(["web.2nsqubits", "web.2nsqubits.p99utjadn", "web.2nsqubits.p99utjadn.id", "web.2nsqubits.p99utjadn.type", "web.2nsqubits.p99utjadn.script", "web.2nsqubits.p99utjadn.styles", "web.2nsqubits.u4mehfi0j", "web.2nsqubits.u4mehfi0j.type"]);
       expect(result.has('64928df20a')).to.be.true;
@@ -394,8 +517,8 @@ describe('store.js', () => {
           url: 'https://test.site.com/index.html'
         }
       });
-      const configKeyStates = { loaded: new Set(["web","web.47b7t1xuc","web.47b7t1xuc.7coo4n5jr","web.47b7t1xuc.7coo4n5jr.id","web.47b7t1xuc.7coo4n5jr.type","web.47b7t1xuc.7coo4n5jr.script","web.47b7t1xuc.7coo4n5jr.styles","web.dependencies","web.bszvsce8f"]), experiments: new Map() };
-      const genomeKeyStates = { loaded: new Set() }
+      const configKeyStates = { experiments: new Map([['913f49193b', new Map([['loaded', new Set(["web","web.47b7t1xuc","web.47b7t1xuc.7coo4n5jr","web.47b7t1xuc.7coo4n5jr.id","web.47b7t1xuc.7coo4n5jr.type","web.47b7t1xuc.7coo4n5jr.script","web.47b7t1xuc.7coo4n5jr.styles","web.dependencies","web.bszvsce8f"])]])]]) };
+      const genomeKeyStates = { experiments: new Map([['913f49193b', new Map([['loaded', new Set()]])]]) };
 
       setActiveAndEntryKeyStates(1, context, config, configKeyStates, genomeKeyStates);
       const result = configKeyStates.experiments;
@@ -601,9 +724,35 @@ describe('store.js', () => {
         }
       }
       context = new Context();
-      configKeyStates = { loaded: new Set(), experiments: new Map() };
-      genomeConfigKeyStates = { loaded: new Set(["web","web.2nsqubits","web.2nsqubits.p99utjadn","web.2nsqubits.p99utjadn.id","web.2nsqubits.p99utjadn.type","web.2nsqubits.p99utjadn.script","web.2nsqubits.p99utjadn.styles","web.2nsqubits.u4mehfi0j","web.2nsqubits.u4mehfi0j.type","web.fiddrbo15","web.fiddrbo15.ma3mr8iy6","web.fiddrbo15.ma3mr8iy6.type","web.ooycjnptz","web.ooycjnptz.lo7yrjkkg","web.ooycjnptz.lo7yrjkkg.type","web.nt1g7tbs2","web.nt1g7tbs2.vzyq1yz56","web.nt1g7tbs2.vzyq1yz56.type","web.2nshubits","web.2nshubits.p89utjadn","web.2nshubits.p89utjadn.id","web.2nshubits.p89utjadn.type","web.2nshubits.p89utjadn.script","web.2nshubits.p89utjadn.styles","web.2nshubits.u4nehfi0j","web.2nshubits.u4nehfi0j.type","web.fidcrbo15","web.fidcrbo15.ma9mr8iy6","web.fidcrbo15.ma9mr8iy6.type","web.ooycjpptz","web.ooycjpptz.lo7yrjkkg","web.ooycjpptz.lo7yrjkkg.type","web.nt1g7tfs2","web.nt1g7tfs2.vzyq1yz56","web.nt1g7tfs2.vzyq1yz56.type"]) };
-    })
+      configKeyStates = { experiments: new Map([]) };
+      genomeConfigKeyStates = { experiments: new Map() };
+
+      config._experiments.forEach(function(exp) {
+        const clean = objects.assign({}, exp);
+        delete clean.id;
+        const expLoaded = new Set();
+        const expMap = new Map();
+        expMap.set('loaded', expLoaded)
+        configKeyStates.experiments.set(exp.id, expMap);
+        objects.flattenKeys(clean, function(key) {
+          return !strings.startsWith(key, '_');
+        }).forEach(expLoaded.add.bind(expLoaded));
+      });
+
+      const expLoaded1 = new Set();
+      const expMap1 = new Map([['loaded', expLoaded1]])
+      genomeConfigKeyStates.experiments.set('60f67d8648', expMap1)
+      objects.flattenKeys(genomes['60f67d8648'], function(key) {
+        return !strings.startsWith(key, '_');
+      }).forEach(expLoaded1.add.bind(expLoaded1));
+
+      const expLoaded2 = new Set();
+      const expMap2 = new Map([['loaded', expLoaded2]])
+      genomeConfigKeyStates.experiments.set('64928df20a', expMap2)
+      objects.flattenKeys(genomes['64928df20a'], function(key) {
+        return !strings.startsWith(key, '_');
+      }).forEach(expLoaded2.add.bind(expLoaded2));
+    });
 
     it('should generate genome for one experiment of two in same environment', () => {
       context.initialize(123, 321, {

--- a/src/tests/store.test.js
+++ b/src/tests/store.test.js
@@ -461,7 +461,7 @@ describe('store.js', () => {
       expect(result.size).to.be.equal(2);
       expect(result.has('60f67d8648')).to.be.true;
       expect(result.get('60f67d8648').has('active')).to.be.true;
-      expect(Array.from(result.get('60f67d8648').get('active'))).to.be.eql(["web","web.2nsqubits","web.2nsqubits.p99utjadn","web.2nsqubits.p99utjadn.id","web.2nsqubits.p99utjadn.type","web.2nsqubits.p99utjadn.script","web.2nsqubits.p99utjadn.styles","web.2nsqubits.u4mehfi0j","web.2nsqubits.u4mehfi0j.type","web.dependencies"]);
+      expect(Array.from(result.get('60f67d8648').get('active'))).to.be.eql(["web","web.dependencies","web.2nsqubits","web.2nsqubits.p99utjadn","web.2nsqubits.p99utjadn.id","web.2nsqubits.p99utjadn.type","web.2nsqubits.p99utjadn.script","web.2nsqubits.p99utjadn.styles","web.2nsqubits.u4mehfi0j","web.2nsqubits.u4mehfi0j.type"]);
       expect(result.get('60f67d8648').has('entry')).to.be.true;
       expect(Array.from(result.get('60f67d8648').get('entry'))).to.be.eql(["web.2nsqubits", "web.2nsqubits.p99utjadn", "web.2nsqubits.p99utjadn.id", "web.2nsqubits.p99utjadn.type", "web.2nsqubits.p99utjadn.script", "web.2nsqubits.p99utjadn.styles", "web.2nsqubits.u4mehfi0j", "web.2nsqubits.u4mehfi0j.type"]);
       expect(result.has('64928df20a')).to.be.true;


### PR DESCRIPTION
Loaded keys weren't experiment aware, this led to two experiments labeling each others keys as active in their active keys set. Which along with my previous change caused all treatments to render. This change makes loaded keys experiment aware so that experiments don't put keys that they don't own into their active set.