### PR TITLE
feat: RKT-8197 - Allow contaminations to be set of all eids

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -251,10 +251,12 @@ function EvolvClient(options) {
    *
    * @param details {Object} Optional. Information on the reason for contamination. If provided, the object should
    * contain a reason. Optionally, a 'details' value should be included for extra debugging info
+   * @param {boolean} allExperiments If true, the user will be excluded from all optimizations, including optimization
+   * not applicable to this page
    */
-  this.contaminate = function(details) {
+  this.contaminate = function(details, allExperiments) {
     const remoteContext = context.remoteContext;
-    const allocations = (remoteContext.experiments || {}).allocations // undefined is a valid state, we want to know if its undefined
+    const allocations = (remoteContext.experiments || {}).allocations; // undefined is a valid state, we want to know if its undefined
     if (!allocations || !allocations.length) {
       return;
     }
@@ -268,7 +270,7 @@ function EvolvClient(options) {
       return conf.cid;
     });
     const contaminatableAllocations = allocations.filter(function(alloc) {
-      return contaminatedCids.indexOf(alloc.cid) < 0 && store.activeEids.has(alloc.eid);
+      return contaminatedCids.indexOf(alloc.cid) < 0 && (allExperiments || store.activeEids.has(alloc.eid));
     });
 
     if (!contaminatableAllocations.length) {

--- a/src/tests/index.test.js
+++ b/src/tests/index.test.js
@@ -772,8 +772,8 @@ describe('Evolv client unit tests', () => {
       Object.defineProperty(store, 'activeEids', { get: function() { return new Set(['1234']); } });
       options.store = store;
 
-      context.initialize();
-      context.set("experiments.allocations", [{eid: '1234', cid: '5678'}]);
+      context.initialize()
+      context.set("experiments.allocations", [{eid: '1234', cid: '5678'}, {eid: '12345', cid: '678910'}]);
       options.context = context;
 
       const client = new Evolv(options);
@@ -833,4 +833,27 @@ describe('Evolv client unit tests', () => {
       expect(context.remoteContext.contaminations[0].cid).to.be.equal('5678');
     });
   })
+
+  it('should contaminate inactive eids when allExperiments is set to true', () => {
+    store.activeEntryPoints = () => new Promise((resolve, reject) => { resolve(['1234']) });
+    Object.defineProperty(store, 'configuration', { get: function() { return { foo: 'bar' }; }, });
+    Object.defineProperty(store, 'activeEids', { get: function() { return new Set(['1234']); } });
+    options.store = store;
+
+    let contaminationDetails = {
+      reason: 'broken',
+      details: 'mistake'
+    };
+
+    context.initialize()
+    context.set("experiments.allocations", [{eid: '1234', cid: '5678'}, {eid: '12345', cid: '678910'}])
+    options.context = context;
+
+    const client = new Evolv(options);
+    client.contaminate(contaminationDetails, true);
+
+    expect(context.remoteContext.contaminations).to.be.lengthOf(2);
+    expect(context.remoteContext.contaminations[0].cid).to.be.equal('5678');
+    expect(context.remoteContext.contaminations[1].cid).to.be.equal('678910');
+  });
 });


### PR DESCRIPTION
The will maintain the current functionality, but when true is
passed to contaminate, it will send contaminations for all
eids into which the user is allocated.