### PR TITLE
fix: AP-436 - Inverting sync value to match XHR API

### DIFF
--- a/src/retrieve.js
+++ b/src/retrieve.js
@@ -104,7 +104,7 @@ function xhrRequest(options) {
       }
     });
     xhr.addEventListener('error', reject);
-    xhr.open(options.method, options.url, options.sync);
+    xhr.open(options.method, options.url, !options.sync);
     if (options.method.toUpperCase() === 'POST' || options.method.toUpperCase() === 'PUT') {
       xhr.setRequestHeader('Content-Type', options.encoding);
     }

--- a/src/tests/index.test.js
+++ b/src/tests/index.test.js
@@ -845,6 +845,9 @@ describe('Evolv client integration tests', () => {
       expect(results.eventPayloads.length).to.equal(0);
 
       evolv.allowEvents();
+
+      await new Promise(resolve => setTimeout(resolve, 1));
+
       expect(results.analyticsPayloads.length).to.equal(1);
       expect(results.analyticsPayloads[0].uid).to.equal(uid);
 


### PR DESCRIPTION
Currently, XHR requests are sync where they're meant to be async which can degrade performance. This commit negates to the "options.sync" parameter to align it to the XHR "async" argument.