### PR TITLE
feat(ap-924): add handlers for new audience props

### DIFF
--- a/src/predicates.js
+++ b/src/predicates.js
@@ -26,8 +26,8 @@ const FILTER_OPERATORS = {
   kv_not_equal: function(obj, params) { return obj[params[0]] !== params[1]; },
   less_than: function(a, b) { return a < b; },
   less_than_or_equal_to: function(a, b) { return a <= b; },
-  typeless_equal: function(a, b) { return a == b; },
-  typeless_not_equal: function(a, b) { return a != b; },
+  loose_equal: function(a, b) { return a == b; },
+  loose_not_equal: function(a, b) { return a != b; },
   regex_match: function(value, pattern) { return value && value.match(pattern); },
   regex64_match: regex64Match,
   starts_with: function(a, b){ return strings.startsWith(a, b); }

--- a/src/predicates.js
+++ b/src/predicates.js
@@ -8,7 +8,12 @@ const FILTER_OPERATORS = {
   contains: function(a, b) { return a.indexOf(b) >= 0; },
   defined: function(a) { return a !== undefined; },
   equal: function(a, b) { return a === b; },
-  exists: function(a) { return a !== null; }, // Check that the key exists in the dictionary object
+  exists: function(a) { return a !== null && a !== undefined }, // Check that the key exists in the dictionary object
+  greater_than: function(a, b) { return a > b; },
+  greater_than_or_equal_to: function(a, b) { return a >= b; },
+  is_true: function(a) { return a === true },
+  is_false: function(a) { return a === false },
+  not_exists: function(a) { return a === null || a === undefined }, // Check that the key does not exists in the dictionary object
   not_contains: function(a, b) { return !(a.indexOf(b) >= 0); },
   not_defined: function(a) { return a === undefined; },
   not_equal: function(a, b) { return a !== b; },
@@ -19,6 +24,8 @@ const FILTER_OPERATORS = {
   kv_equal: function(obj, params) { return obj[params[0]] === params[1]; },
   kv_not_contains: function(obj, params) { return !((params[0] in obj) && (obj[params[0]].indexOf(params[1]) >= 0)); },
   kv_not_equal: function(obj, params) { return obj[params[0]] !== params[1]; },
+  less_than: function(a, b) { return a < b; },
+  less_than_or_equal_to: function(a, b) { return a <= b; },
   regex_match: function(value, pattern) { return value && value.match(pattern); },
   regex64_match: regex64Match,
   starts_with: function(a, b){ return strings.startsWith(a, b); }

--- a/src/predicates.js
+++ b/src/predicates.js
@@ -26,6 +26,8 @@ const FILTER_OPERATORS = {
   kv_not_equal: function(obj, params) { return obj[params[0]] !== params[1]; },
   less_than: function(a, b) { return a < b; },
   less_than_or_equal_to: function(a, b) { return a <= b; },
+  typeless_equal: function(a, b) { return a == b; },
+  typeless_not_equal: function(a, b) { return a != b; },
   regex_match: function(value, pattern) { return value && value.match(pattern); },
   regex64_match: regex64Match,
   starts_with: function(a, b){ return strings.startsWith(a, b); }

--- a/src/tests/predicates.test.js
+++ b/src/tests/predicates.test.js
@@ -648,6 +648,54 @@ describe('predicates.js', () => {
       assert.equal(1, result.passed.size);
       assert.equal(0, result.failed.size);
     });
+
+    it('should evaluate "Typeless equal" property', () => {
+      const predicate = {
+        id: 123,
+        combinator: 'and',
+        rules: [
+          {
+            field: 'web.pageWidth',
+            operator: 'typeless_equal',
+            value: 1200,
+            index: 0
+          }
+        ]
+      };
+      const context = {
+        web:{
+          pageWidth: 1200
+        },
+      };
+      const result = predicates.evaluate(context, predicate);
+      assert(!result.rejected);
+      assert.equal(1, result.passed.size);
+      assert.equal(0, result.failed.size);
+    });
+
+    it('should evaluate "Typeless not_equal" property', () => {
+      const predicate = {
+        id: 123,
+        combinator: 'and',
+        rules: [
+          {
+            field: 'web.pageWidth',
+            operator: 'typeless_not_equal',
+            value: 1250,
+            index: 0
+          }
+        ]
+      };
+      const context = {
+        web:{
+          pageWidth: 1200
+        },
+      };
+      const result = predicates.evaluate(context, predicate);
+      assert(!result.rejected);
+      assert.equal(1, result.passed.size);
+      assert.equal(0, result.failed.size);
+    });
     
   });
 });

--- a/src/tests/predicates.test.js
+++ b/src/tests/predicates.test.js
@@ -509,6 +509,9 @@ describe('predicates.js', () => {
           }]
       };
       const context = {
+        web:{
+          referrer: 'localhost'
+        },
         platform: 'ios',
       };
       const result = predicates.evaluate(context, predicate);
@@ -516,5 +519,135 @@ describe('predicates.js', () => {
       assert.equal(2, result.passed.size);
       assert.equal(0, result.failed.size);
     });
+
+    it('should evaluate greater than and less than properties', () => {
+      const predicate = {
+        id: 123,
+        combinator: 'and',
+        rules: [
+          {
+            field: 'web.pageWidth',
+            operator: 'greater_than',
+            value: 1200,
+            index: 0
+          },
+          {
+            field: 'web.pageWidth',
+            operator: 'less_than',
+            value: 1400,
+            index: 0
+          }
+        ]
+      };
+      const context = {
+        web:{
+          pageWidth: 1300
+        },
+      };
+      const result = predicates.evaluate(context, predicate);
+      assert(!result.rejected);
+      assert.equal(2, result.passed.size);
+      assert.equal(0, result.failed.size);
+    });
+
+    it('should evaluate "greater than or equal to" and "less than or equal to" properties', () => {
+      const predicate = {
+        id: 123,
+        combinator: 'and',
+        rules: [
+          {
+            field: 'web.pageWidth',
+            operator: 'greater_than_or_equal_to',
+            value: 1200,
+            index: 0
+          },
+          {
+            field: 'web.pageWidth',
+            operator: 'less_than_or_equal_to',
+            value: 1500,
+            index: 0
+          }
+        ]
+      };
+      const context = {
+        web:{
+          pageWidth: 1200
+        },
+      };
+      const result = predicates.evaluate(context, predicate);
+      assert(!result.rejected);
+      assert.equal(2, result.passed.size);
+      assert.equal(0, result.failed.size);
+    });
+
+    it('should evaluate "does not exist" property', () => {
+      const predicate = {
+        id: 123,
+        combinator: 'and',
+        rules: [
+          {
+            field: 'platform',
+            operator: 'not_exists',
+            index: 0
+          }
+        ]
+      };
+      const context = {
+        web:{
+          pageWidth: 1200
+        },
+      };
+      const result = predicates.evaluate(context, predicate);
+      assert(!result.rejected);
+      assert.equal(1, result.passed.size);
+      assert.equal(0, result.failed.size);
+    });
+
+    it('should evaluate "is True" property', () => {
+      const predicate = {
+        id: 123,
+        combinator: 'and',
+        rules: [
+          {
+            field: 'web.isDesktop',
+            operator: 'is_true',
+            index: 0
+          }
+        ]
+      };
+      const context = {
+        web:{
+          isDesktop: true
+        },
+      };
+      const result = predicates.evaluate(context, predicate);
+      assert(!result.rejected);
+      assert.equal(1, result.passed.size);
+      assert.equal(0, result.failed.size);
+    });
+
+    it('should evaluate "is False" property', () => {
+      const predicate = {
+        id: 123,
+        combinator: 'and',
+        rules: [
+          {
+            field: 'web.isDesktop',
+            operator: 'is_false',
+            index: 0
+          }
+        ]
+      };
+      const context = {
+        web:{
+          isDesktop: false
+        },
+      };
+      const result = predicates.evaluate(context, predicate);
+      assert(!result.rejected);
+      assert.equal(1, result.passed.size);
+      assert.equal(0, result.failed.size);
+    });
+    
   });
 });

--- a/src/tests/predicates.test.js
+++ b/src/tests/predicates.test.js
@@ -656,7 +656,7 @@ describe('predicates.js', () => {
         rules: [
           {
             field: 'web.pageWidth',
-            operator: 'typeless_equal',
+            operator: 'loose_equal',
             value: 1200,
             index: 0
           }
@@ -680,7 +680,7 @@ describe('predicates.js', () => {
         rules: [
           {
             field: 'web.pageWidth',
-            operator: 'typeless_not_equal',
+            operator: 'loose_not_equal',
             value: 1250,
             index: 0
           }


### PR DESCRIPTION
[Ticket](https://evolv-ai.atlassian.net/jira/software/c/projects/AP/boards/2?modal=detail&selectedIssue=AP-924)

Added handlers for new audience fields

Fix: **updated 'exists' handler.**
When tested noticed that even the field does not exist in **evolv.context.remoteContext** we are still in target and changes were applied. Added additional check that property is not **undefined** (before we checked that it is not **null** only)
@robertsevernsentient @tfoster Please confirm that I can make this change to the existing audience property handler