### PR TITLE
feat(AP-773): support for request hooks

### DIFF
--- a/src/build-options.js
+++ b/src/build-options.js
@@ -1,0 +1,36 @@
+import { assign } from './ponyfills/objects.js';
+
+/**
+ * @typedef EvolvClientOptions
+ * @property {string} environment
+ * @property {number} version
+ * @property {string} endpoint
+ * @property {boolean} autoConfirm
+ * @property {boolean} analytics
+ * @property {*} [store]
+ * @property {*} [context]
+ * @property {*} [auth]
+ * @property {boolean} [bufferEvents]
+ */
+
+/**
+ * @param {Partial<EvolvClientOptions>} options
+ * @returns EvolvClientOptions
+ */
+export function buildOptions(options) {
+  const opts = assign({}, options);
+
+  if (!opts.environment) {
+    throw new Error('"environment" must be specified');
+  }
+
+  if (!('autoConfirm' in opts)) {
+    opts.autoConfirm = true;
+  }
+
+  opts.version = opts.version || 1;
+  opts.endpoint = (opts.endpoint || 'https://participants.evolv.ai/') + 'v' + opts.version;
+  opts.analytics = 'analytics' in opts ? opts.analytics : opts.version > 1;
+
+  return opts;
+}

--- a/src/build-options.js
+++ b/src/build-options.js
@@ -1,11 +1,17 @@
 import { assign } from './ponyfills/objects.js';
 
 /**
+ * @typedef RequestHooks
+ * @property {(options: RetrieveOptions) => RetrieveOptions} [beforeOptions]
+ */
+
+/**
  * @typedef EvolvClientOptions
  * @property {string} environment
  * @property {number} version
  * @property {string} endpoint
  * @property {boolean} autoConfirm
+ * @property {RequestHooks} hooks
  * @property {boolean} analytics
  * @property {*} [store]
  * @property {*} [context]
@@ -31,6 +37,8 @@ export function buildOptions(options) {
   opts.version = opts.version || 1;
   opts.endpoint = (opts.endpoint || 'https://participants.evolv.ai/') + 'v' + opts.version;
   opts.analytics = 'analytics' in opts ? opts.analytics : opts.version > 1;
+
+  opts.hooks = assign({}, opts.hooks);
 
   return opts;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ import Store, { EFFECTIVE_GENOME_UPDATED, REQUEST_FAILED } from './store.js';
 import { waitFor, waitOnceFor, emit, destroyScope } from './waitforit.js';
 import Beacon from './beacon.js';
 import { assign } from './ponyfills/objects.js';
+import { buildOptions } from './build-options.js';
 
 /**
  * @typedef {Promise} SubscribablePromise
@@ -23,23 +24,13 @@ import { assign } from './ponyfills/objects.js';
  *
  * The client provides asynchronous access to key states, values, contexts, and configurations.
  *
- * @param options {Object} An object of options for the client.
+ * @param opts {Partial<EvolvClientOptions>} An object of options for the client.
  * @constructor
  */
-function EvolvClient(options) {
+function EvolvClient(opts) {
   let initialized = false;
 
-  if (!options.environment) {
-    throw new Error('"environment" must be specified');
-  }
-
-  if (!('autoConfirm' in options)) {
-    options.autoConfirm = true;
-  }
-
-  options.version = options.version || 1;
-  options.endpoint = (options.endpoint || 'https://participants.evolv.ai/') + 'v' + options.version;
-  options.analytics = 'analytics' in options ? options.analytics : options.version > 1;
+  const options = buildOptions(opts);
 
   const store = options.store || new Store(options);
   const context = options.context || new Context(store);

--- a/src/retrieve.js
+++ b/src/retrieve.js
@@ -154,7 +154,26 @@ function nodeRequest(options) {
   });
 }
 
-export default function retrieve(options) {
+/**
+ * @typedef RetrieveOptions
+ * @property {string} method
+ * @property {string} url
+ * @property {string} keyId
+ * @property {string} key
+ * @property {object|*} [data]
+ * @property {string} [encoding]
+ */
+
+/**
+ * @param {RetrieveOptions} opts
+ * @param {RequestHooks} [hooks]
+ * @returns {Promise<unknown> | MiniPromise}
+ */
+export default function retrieve(opts, hooks) {
+  const options = (hooks && typeof hooks.beforeOptions === 'function')
+    ? hooks.beforeOptions(opts)
+    : opts;
+
   return MiniPromise.createPromise(function(resolve, reject) {
     const completeOptions = assign({}, options);
     completeOptions.encoding = completeOptions.encoding || 'application/json; charset=UTF-8';

--- a/src/store.js
+++ b/src/store.js
@@ -363,6 +363,10 @@ export function generateEffectiveGenome(expsKeyStates, genomes) {
   }
 }
 
+/**
+ * @param {Partial<EvolvClientOptions>} options
+ * @constructor
+ */
 function EvolvStore(options) {
   const version = options.version || 1;
   const prefix = options.endpoint + '/' + options.environment;
@@ -657,7 +661,7 @@ function EvolvStore(options) {
         url: prefix + '/' + context.uid + '/configuration.json',
         keyId: keyId,
         key: key
-      })
+      }, options.hooks)
         .then(update.bind(this, true, requestedKeys))
         .catch(failed.bind(this, true, requestedKeys));
       moveKeys(requestedKeys, configKeyStates.needed, configKeyStates.requested);
@@ -673,7 +677,7 @@ function EvolvStore(options) {
         url: prefix + '/' + context.uid + '/allocations',
         keyId: keyId,
         key: key
-      })
+      }, options.hooks)
         .then(update.bind(this, false, requestedKeys))
         .catch(failed.bind(this, false, requestedKeys));
       moveKeys(requestedKeys, genomeKeyStates.needed, genomeKeyStates.requested);

--- a/src/tests/index.test.js
+++ b/src/tests/index.test.js
@@ -5,9 +5,10 @@ import webcrypto from 'webcrypto';
 
 import Evolv from '../index.js';
 import Store, { EFFECTIVE_GENOME_UPDATED } from '../store.js';
-import Context, { CONTEXT_INITIALIZED, CONTEXT_CHANGED } from "../context.js";
+import Context, { CONTEXT_INITIALIZED, CONTEXT_CHANGED } from '../context.js';
 import { waitFor, emit } from '../waitforit.js';
-import base64 from "../ponyfills/base64.js";
+import base64 from '../ponyfills/base64.js';
+import { buildOptions } from '../build-options.js';
 
 chai.use(spies);
 const expect = chai.expect;
@@ -31,7 +32,8 @@ async function validateSignature(keys, signature, body) {
   return await crypto.subtle.verify(algorithm, cryptoKey, signatureData, textEncoder.encode(body).buffer);
 }
 
-async function validateClient(evolv, options, uid, sid) {
+async function validateClient(evolv, opts, uid, sid) {
+  const options = buildOptions(opts);
   let initializedSpy = chai.spy();
   evolv.once(Evolv.INITIALIZED, initializedSpy);
   expect(initializedSpy).to.not.have.been.called;


### PR DESCRIPTION
The purpose of this change is allow users of the SDK to modify HTTP requests before they are sent out. The express need is so that the asset manager can append a `previewcid` query parameter.

I'm not 100% certain this is the best approach, so alternative approaches are welcome.