### PR TITLE
feat(ap-974): make `strings.hashCode` to use `hashing.objectHash`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -514,6 +514,12 @@
       "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
       "dev": true
     },
+    "@sentienttechnologies/hashing": {
+      "version": "1.0.0",
+      "resolved": "https://npm.pkg.github.com/download/@sentienttechnologies/hashing/1.0.0/0f58383148855ea9d4aafe7f55a66bf75b0449d22e1a543e76946eb2913997c6",
+      "integrity": "sha512-3to730OYpYnUmzYK7qqFYfI8+EK8vaki2xIJXCgnKna+4aiCQBO7FFagdNWIB2KcHJsQvpB1E1DqyNCdcfFMog==",
+      "dev": true
+    },
     "@types/eslint": {
       "version": "7.2.8",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.8.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -423,6 +423,11 @@
         }
       }
     },
+    "@evolv/hashing": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@evolv/hashing/-/hashing-1.1.0.tgz",
+      "integrity": "sha512-PhqiRNwX+0hxl1Y94ytmDVMbqeG3l2JMJ1Ip4BznQr7cGd36YIfl4glb+W9lgaN/p22+TAhCapzUFfIlpVOGbw=="
+    },
     "@humanwhocodes/config-array": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.6.0.tgz",
@@ -512,12 +517,6 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
       "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
-      "dev": true
-    },
-    "@sentienttechnologies/hashing": {
-      "version": "1.0.0",
-      "resolved": "https://npm.pkg.github.com/download/@sentienttechnologies/hashing/1.0.0/0f58383148855ea9d4aafe7f55a66bf75b0449d22e1a543e76946eb2913997c6",
-      "integrity": "sha512-3to730OYpYnUmzYK7qqFYfI8+EK8vaki2xIJXCgnKna+4aiCQBO7FFagdNWIB2KcHJsQvpB1E1DqyNCdcfFMog==",
       "dev": true
     },
     "@types/eslint": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
   "license": "MIT",
   "dependencies": {
     "base64-arraybuffer": "^0.2.0",
-    "deepmerge": "^4.2.2"
+    "deepmerge": "^4.2.2",
+    "@sentienttechnologies/hashing": "^1.0.0"
   },
   "devDependencies": {
     "@istanbuljs/esm-loader-hook": "^0.1.2",

--- a/package.json
+++ b/package.json
@@ -48,9 +48,9 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@evolv/hashing": "^1.1.0",
     "base64-arraybuffer": "^0.2.0",
-    "deepmerge": "^4.2.2",
-    "@sentienttechnologies/hashing": "^1.0.0"
+    "deepmerge": "^4.2.2"
   },
   "devDependencies": {
     "@istanbuljs/esm-loader-hook": "^0.1.2",

--- a/src/ponyfills/strings.js
+++ b/src/ponyfills/strings.js
@@ -1,5 +1,3 @@
-import hashing from '@evolv/hashing'
-
 /**
  * Method determines whether a string begins with the characters of a specified string,
  * returning true or false as appropriate.
@@ -33,11 +31,3 @@ export function endsWith(string, searchString, length) {
 	const len = length === undefined || length > string.length ? string.length : length;
 	return string.substring(len - searchString.length, len) === searchString;
 }
-
-/**
- * Method produces a consistent numeric hash for a string.
- *
- * @param string The string to be hashed
- * @returns {number} The numeric hash of the string
- */
-export const hashCode = hashing.objectHash;

--- a/src/ponyfills/strings.js
+++ b/src/ponyfills/strings.js
@@ -1,4 +1,4 @@
-import hashing from '@sentienttechnologies/hashing'
+import hashing from '@evolv/hashing'
 
 /**
  * Method determines whether a string begins with the characters of a specified string,

--- a/src/ponyfills/strings.js
+++ b/src/ponyfills/strings.js
@@ -1,3 +1,5 @@
+import hashing from '@sentienttechnologies/hashing'
+
 /**
  * Method determines whether a string begins with the characters of a specified string,
  * returning true or false as appropriate.
@@ -38,9 +40,4 @@ export function endsWith(string, searchString, length) {
  * @param string The string to be hashed
  * @returns {number} The numeric hash of the string
  */
-export function hashCode(string) {
-  for(var ret = 0, i = 0, len = string.length; i < len; i++) {
-    ret = (31 * ret + string.charCodeAt(i)) << 0;
-  }
-  return ret;
-}
+export const hashCode = hashing.objectHash;

--- a/src/ponyfills/tests/strings.test.js
+++ b/src/ponyfills/tests/strings.test.js
@@ -4,36 +4,6 @@ import * as strings from '../strings.js';
 const { expect } = chai;
 
 describe('strings', () => {
-  describe('hashCode', () => {
-    const string1 = JSON.stringify({
-      id: 123,
-      type: 'hybrid',
-      disabled: false,
-      value: 'console.log("HELLO")'
-    })
-    const string2 = JSON.stringify({
-      id: 123,
-      type: 'hybrid',
-      disabled: false,
-      value: 'console.log("HI")'
-    })
-
-    it('should produce a consistant hash for a stringified JSON object', () => {
-      const value = strings.hashCode(string1)
-
-      expect(value).to.be.equal(1414479601)
-    });
-
-    it('should produce a different hash for two different stringified JSON objects', () => {
-      const value1 = strings.hashCode(string1)
-      const value2 = strings.hashCode(string2)
-
-      expect(value1).to.not.be.equal(value2)
-      expect(value1).to.be.equal(1414479601)
-      expect(value2).to.be.equal(1283140696)
-    });
-  });
-
   describe('endsWith', () => {
     it('should match strings endings', () => {
       expect(strings.endsWith('A String Example', 'ple')).to.be.equal(true);

--- a/src/store.js
+++ b/src/store.js
@@ -472,7 +472,7 @@ function EvolvStore(options) {
         })
         const pruned = objects.prune(effectiveGenome, active);
         Object.keys(pruned).forEach(function(key) {
-          activeVariants.add(key.concat(':', strings.hashCode(JSON.stringify(pruned[key]))));
+          activeVariants.add(key.concat(':', strings.hashCode(pruned[key])));
         });
       }
     });

--- a/src/store.js
+++ b/src/store.js
@@ -2,6 +2,8 @@ import MiniPromise from './ponyfills/minipromise.js';
 import { fromArray } from './ponyfills/arrays.js';
 import * as objects from './ponyfills/objects.js';
 import * as strings from './ponyfills/strings.js';
+import { objectHash } from '@evolv/hashing';
+
 
 import { copySet } from './helpers/set-utils.js';
 import { evaluate } from './predicates.js';
@@ -472,7 +474,7 @@ function EvolvStore(options) {
         })
         const pruned = objects.prune(effectiveGenome, active);
         Object.keys(pruned).forEach(function(key) {
-          activeVariants.add(key.concat(':', strings.hashCode(pruned[key])));
+          activeVariants.add(key.concat(':', objectHash(pruned[key])));
         });
       }
     });

--- a/src/tests/index.test.js
+++ b/src/tests/index.test.js
@@ -667,7 +667,7 @@ describe('Evolv client integration tests', () => {
       expect(messages[6].sid).to.equal(sid)
       expect(messages[7].type).to.equal("context.value.changed")
       expect(messages[7].payload.key).to.equal("variants.active")
-      expect(messages[7].payload.value).to.eql(["web.ab8numq2j.am94yhwo2:1813410159"])
+      expect(messages[7].payload.value).to.eql(["web.ab8numq2j.am94yhwo2:1486101989"])
       expect(messages[7].sid).to.equal(sid)
       expect(messages[8].type).to.equal("context.value.added")
       expect(messages[8].payload.key).to.equal("confirmations")

--- a/webpack.common.cjs
+++ b/webpack.common.cjs
@@ -18,6 +18,7 @@ module.exports = {
     http: { commonjs: 'http' },
     https: { commonjs: 'https' },
     deepmerge: { commonjs2: 'deepmerge' },
-    'base64-arraybuffer': { commonjs2: 'base64-arraybuffer' }
+    'base64-arraybuffer': { commonjs2: 'base64-arraybuffer' },
+    '@sentienttechnologies/hashing': { commonjs2: '@sentienttechnologies/hashing' }
   }
 };

--- a/webpack.common.cjs
+++ b/webpack.common.cjs
@@ -18,7 +18,6 @@ module.exports = {
     http: { commonjs: 'http' },
     https: { commonjs: 'https' },
     deepmerge: { commonjs2: 'deepmerge' },
-    'base64-arraybuffer': { commonjs2: 'base64-arraybuffer' },
-    '@sentienttechnologies/hashing': { commonjs2: '@sentienttechnologies/hashing' }
+    'base64-arraybuffer': { commonjs2: 'base64-arraybuffer' }
   }
 };


### PR DESCRIPTION
All repositories should use the same hashing module. JavaScript-SDK was using it's own.