### PR TITLE
ci: restrict set of files included in package bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,10 @@
     "url": "https://github.com/evolv-ai/javascript-sdk/issues",
     "email": "support@evolv.ai"
   },
+  "files": [
+    "dist/**/*",
+    "src/**/*"
+  ],
   "directories": {
     "doc": "./docs"
   },


### PR DESCRIPTION
the bundle currently includes most of the files in the repo including build files and deployment scripts