### PR TITLE
fix(ap-1844): added limit to analytic beacon retries.

### DIFF
--- a/src/beacon.js
+++ b/src/beacon.js
@@ -95,7 +95,7 @@ export default function Emitter(endpoint, context, options) {
         editedMessage = message.payload || {};
         editedMessage.type = message.type;
         if (!send(endpoint, JSON.stringify(editedMessage), sync) && retries) {
-          --retries
+          retries -= 1;
           messages.push(message);
           console.error('Evolv: Unable to send event beacon');
         }
@@ -109,9 +109,8 @@ export default function Emitter(endpoint, context, options) {
         }
 
         if (!send(endpoint, JSON.stringify(wrapMessages(smallBatch)), sync) && retries) {
-          console.log('retries', retries)
-          --retries
-          messages = smallBatch
+          retries -= 1;
+          messages = smallBatch;
           console.error('Evolv: Unable to send analytics beacon');
           break;
         }

--- a/src/beacon.js
+++ b/src/beacon.js
@@ -4,10 +4,7 @@ import { assign, omitUndefined } from './ponyfills/objects.js';
 const DELAY = 1;
 const ENDPOINT_PATTERN = /\/(v\d+)\/\w+\/([a-z]+)$/i;
 const BATCH_SIZE = 25;
-export const RETRIES = {
-  max: 3,
-  current: 0
-};
+export const RETRIES = 3;
 
 function fallbackBeacon(url, data, sync) {
   retrieve({
@@ -70,7 +67,10 @@ export default function Emitter(endpoint, context, options) {
     }
   }
 
-  function transmit() {
+  /**
+   * @param retries
+   */
+  function transmit(retries = RETRIES) {
     let sync = false;
     if (typeof this !== 'undefined' && this !== null) {
       const currentEvent = this.event && this.event.type;
@@ -94,9 +94,8 @@ export default function Emitter(endpoint, context, options) {
         let editedMessage = message;
         editedMessage = message.payload || {};
         editedMessage.type = message.type;
-
-        if (!send(endpoint, JSON.stringify(editedMessage), sync) && RETRIES.current) {
-          --RETRIES.current
+        if (!send(endpoint, JSON.stringify(editedMessage), sync) && retries) {
+          --retries
           messages.push(message);
           console.error('Evolv: Unable to send event beacon');
         }
@@ -109,8 +108,9 @@ export default function Emitter(endpoint, context, options) {
           break;
         }
 
-        if (!send(endpoint, JSON.stringify(wrapMessages(smallBatch)), sync) && RETRIES.current) {
-          --RETRIES.current
+        if (!send(endpoint, JSON.stringify(wrapMessages(smallBatch)), sync) && retries) {
+          console.log('retries', retries)
+          --retries
           messages = smallBatch
           console.error('Evolv: Unable to send analytics beacon');
           break;
@@ -121,7 +121,7 @@ export default function Emitter(endpoint, context, options) {
     }
 
     if (messages.length) {
-      timer = setTimeout(transmit, DELAY);
+      timer = setTimeout(function() {transmit(retries)}, DELAY);
     }
   }
 
@@ -136,7 +136,6 @@ export default function Emitter(endpoint, context, options) {
   };
 
   this.emit = function(type, payload, flush) {
-    RETRIES.current = RETRIES.max
     messages.push({
       type: type,
       payload: payload,

--- a/src/tests/beacon.test.js
+++ b/src/tests/beacon.test.js
@@ -1,0 +1,50 @@
+import chai from 'chai';
+import spies from 'chai-spies';
+
+import Beacon, { RETRIES } from '../beacon.js';
+
+chai.use(spies);
+const expect = chai.expect;
+describe('beacon', () => {
+  const endpointV2 = 'https://participants-frazer.evolv.ai/v2';
+  beforeEach(() => {
+    global.windowRef = global.window
+  })
+  afterEach(() => {
+    global.window = global.windowRef
+  })
+
+  it('emit without infinite loop', (done) => {
+    console.log('test start')
+    global.window = { addEventListener: () => null , navigator: { sendBeacon: () => false } };
+    const beacon = new Beacon(endpointV2, { uid: '' }, '');
+    let spy = chai.spy.on(console, 'error')
+
+    beacon.emit('error', '{msg', true)
+    beacon.emit('error', '{msg', true)
+    beacon.emit('error', '{msg', true)
+    beacon.emit('error', '{msg', true)
+    beacon.emit('error', '{msg', true)
+    beacon.emit('error', '{msg', true)
+    beacon.emit('error', '{msg', true)
+    beacon.emit('error', '{msg', true)
+    beacon.emit('error', '{msg', true)
+
+    setTimeout(() => {
+      const firstState = 9 + RETRIES.max - 1
+      expect(spy).to.have.been.called(firstState);
+
+      beacon.emit('error', '{msg', true)
+      beacon.emit('error', '{msg', true)
+      beacon.emit('error', '{msg', true)
+      beacon.emit('error', '{msg', true)
+
+      setTimeout(() => {
+        const secondState = firstState + 4 + RETRIES.max - 1
+        expect(spy).to.have.been.called(secondState);
+        done()
+      }, 500)
+    }, 500)
+
+  });
+});

--- a/src/tests/beacon.test.js
+++ b/src/tests/beacon.test.js
@@ -31,7 +31,7 @@ describe('beacon', () => {
     beacon.emit('error', '{msg', true)
 
     setTimeout(() => {
-      const firstState = 9 + RETRIES.max - 1
+      const firstState = 9 + RETRIES - 1
       expect(spy).to.have.been.called(firstState);
 
       beacon.emit('error', '{msg', true)
@@ -40,7 +40,7 @@ describe('beacon', () => {
       beacon.emit('error', '{msg', true)
 
       setTimeout(() => {
-        const secondState = firstState + 4 + RETRIES.max - 1
+        const secondState = firstState + 4 + RETRIES - 1
         expect(spy).to.have.been.called(secondState);
         done()
       }, 500)


### PR DESCRIPTION
Without this limit, whenever the beacon fails, we become stuck in a loop where we throw errors in the console and crash the user's device.