### PR TITLE
fix(AP-1778): reorder exports in package.json

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -28,6 +28,8 @@
         "rollup.config.js"
       ],
       "rules": {
+        "object-shorthand": "off",
+        "es/no-arrow-functions": "off",
         "es/no-spread-elements": "off",
         "es/no-template-literals": "off"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "@evolv/client",
       "version": "2.1.0",
-      "license": "MIT",
+      "license": "Apache-2.0",
       "devDependencies": {
         "@istanbuljs/esm-loader-hook": "^0.1.2",
         "@peculiar/webcrypto": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
   "module": "dist/browser/index.mjs",
   "types": "dist/types.d.ts",
   "exports": {
+    "node": "./dist/node/index.mjs",
     "import": "./dist/browser/index.mjs",
-    "require": "./dist/browser/index.cjs",
-    "node": "./dist/node/index.mjs"
+    "require": "./dist/browser/index.cjs"
   },
   "homepage": "https://www.evolv.ai",
   "bugs": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -9,7 +9,7 @@ import manifest from './package.json';
 
 const banner = () => {
   const year = new Date().getFullYear();
-  const version = (process?.env?.SEM_VER ?? manifest.version)
+  const version = (process?.env?.SEM_VER ?? manifest.version) // eslint-disable-line no-undef
     .replace(/\*\//gm, ''); // Prevents injection
 
   const comment = outdent`


### PR DESCRIPTION
earlier entries have priority, so "node" was being ignored since "import" was listed earlier