### PR TITLE
fix(AP-1778): fix import statement for base64-arraybuffer

### DIFF
--- a/src/ponyfills/base64.js
+++ b/src/ponyfills/base64.js
@@ -1,4 +1,4 @@
-import base64ab from 'base64-arraybuffer';
+import * as base64ab from 'base64-arraybuffer';
 
 export default {
   encode: function(bytes) {


### PR DESCRIPTION
package does not export a default and thus breaks downstream usages