### PR TITLE
Add a promise for confirm

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ import { waitFor, waitOnceFor, emit, destroyScope, removeListener } from './wait
 import Beacon from './beacon.js';
 import { assign } from './ponyfills/objects.js';
 import { buildOptions } from './build-options.js';
+import MiniPromise from './ponyfills/minipromise.js';
 
 /**
  * @typedef {Promise} SubscribablePromise
@@ -228,7 +229,7 @@ function EvolvClient(opts) {
    */
   this.confirm = function() {
     // eslint-disable-next-line es/no-promise
-    return new Promise(function(resolve) {
+    return new MiniPromise.createPromise(function(resolve) {
       waitFor(context, EFFECTIVE_GENOME_UPDATED,function() {
         const remoteContext = context.remoteContext;
         const allocations = (remoteContext.experiments || {}).allocations // undefined is a valid state, we want to know if its undefined


### PR DESCRIPTION
Add a promise for confirm method, so we can use it to understand if all confirmations have been sent.
Tested by using setTimeout instead of `waitFor` . See screenrecording:


https://user-images.githubusercontent.com/95315222/213318349-260dbdd8-497a-4806-a7f7-645cc8e6edc1.mov

