### PR TITLE
feat(AP-2109): Changed the path for each timer option

### DIFF
--- a/src/tests/time-context.test.js
+++ b/src/tests/time-context.test.js
@@ -32,28 +32,28 @@ describe('updateTimeContext', () => {
     describe('initial time set', () => {
         it('should set the correct utc time info on the local context', () => {
             addDateTimeToContext(context);
-            expect(context.get('utc.time.minute')).to.equal(12);
-            expect(context.get('utc.time.hour')).to.equal(11);
-            expect(context.get('utc.date.day')).to.equal(14);
-            expect(context.get('utc.date.month')).to.equal(6);
-            expect(context.get('utc.date.year')).to.equal(2017);
+            expect(context.get('dateTime.utc.time.minute')).to.equal(12);
+            expect(context.get('dateTime.utc.time.hour')).to.equal(11);
+            expect(context.get('dateTime.utc.date.day')).to.equal(14);
+            expect(context.get('dateTime.utc.date.month')).to.equal(6);
+            expect(context.get('dateTime.utc.date.year')).to.equal(2017);
         });
 
         it('should set the correct local time info on the local context', () => {
             addDateTimeToContext(context);
-            expect(context.get('time.minute')).to.equal(12);
+            expect(context.get('dateTime.local.time.minute')).to.equal(12);
             // Cannot override the timezone, so we can't test the local time
-            // expect(context.get('time.hour')).to.equal(4);
-            expect(context.get('date.day')).to.equal(14);
-            expect(context.get('date.month')).to.equal(6);
-            expect(context.get('date.year')).to.equal(2017);
+            // expect(context.get('dateTime.local.time.hour')).to.equal(4);
+            expect(context.get('dateTime.local.date.day')).to.equal(14);
+            expect(context.get('dateTime.local.date.month')).to.equal(6);
+            expect(context.get('dateTime.local.date.year')).to.equal(2017);
         });
 
         it('should set the correct day of week and hour of day on the local context', () => {
             addDateTimeToContext(context);
-            expect(context.get('dayOfWeek')).to.equal(3);
+            expect(context.get('dateTime.local.dayOfWeek')).to.equal(3);
             // Cannot override the timezone, so we can't test the local time
-            // expect(context.get('hourOfDay')).to.equal(4);
+            // expect(context.get('dateTime.local.hourOfDay')).to.equal(4);
         });
     });
 
@@ -65,56 +65,56 @@ describe('updateTimeContext', () => {
             clock = useFakeTimers(testDate.getTime());
 
             addDateTimeToContext(context);
-            expect(context.get('utc.time.minute')).to.equal(59);
-            expect(context.get('utc.time.hour')).to.equal(23);
-            expect(context.get('utc.date.day')).to.equal(31);
-            expect(context.get('utc.date.month')).to.equal(12);
-            expect(context.get('utc.date.year')).to.equal(2017);
+            expect(context.get('dateTime.utc.time.minute')).to.equal(59);
+            expect(context.get('dateTime.utc.time.hour')).to.equal(23);
+            expect(context.get('dateTime.utc.date.day')).to.equal(31);
+            expect(context.get('dateTime.utc.date.month')).to.equal(12);
+            expect(context.get('dateTime.utc.date.year')).to.equal(2017);
 
             // Cannot override the timezone, so we can't test the local time
-            /*expect(context.get('time.minute')).to.equal(59);
-            expect(context.get('time.hour')).to.equal(15);
-            expect(context.get('date.day')).to.equal(31);
-            expect(context.get('date.month')).to.equal(12);
-            expect(context.get('date.year')).to.equal(2017);*/
+            /*expect(context.get('dateTime.local.time.minute')).to.equal(59);
+            expect(context.get('dateTime.local.time.hour')).to.equal(15);
+            expect(context.get('dateTime.local.date.day')).to.equal(31);
+            expect(context.get('dateTime.local.date.month')).to.equal(12);
+            expect(context.get('dateTime.local.date.year')).to.equal(2017);*/
 
             clock.tick(120000);
 
-            expect(context.get('utc.time.minute')).to.equal(1);
-            expect(context.get('utc.time.hour')).to.equal(0);
-            expect(context.get('utc.date.day')).to.equal(1);
-            expect(context.get('utc.date.month')).to.equal(1);
-            expect(context.get('utc.date.year')).to.equal(2018);
+            expect(context.get('dateTime.utc.time.minute')).to.equal(1);
+            expect(context.get('dateTime.utc.time.hour')).to.equal(0);
+            expect(context.get('dateTime.utc.date.day')).to.equal(1);
+            expect(context.get('dateTime.utc.date.month')).to.equal(1);
+            expect(context.get('dateTime.utc.date.year')).to.equal(2018);
 
             // Cannot override the timezone, so we can't test the local time
-            /*expect(context.get('time.minute')).to.equal(1);
-            expect(context.get('time.hour')).to.equal(16);
-            expect(context.get('date.day')).to.equal(31);
-            expect(context.get('date.month')).to.equal(12);
-            expect(context.get('date.year')).to.equal(2017);*/
+            /*expect(context.get('dateTime.local.time.minute')).to.equal(1);
+            expect(context.get('dateTime.local.time.hour')).to.equal(16);
+            expect(context.get('dateTime.local.date.day')).to.equal(31);
+            expect(context.get('dateTime.local.date.month')).to.equal(12);
+            expect(context.get('dateTime.local.date.year')).to.equal(2017);*/
         });
     });
 
     describe('polling time updates', () => {
         it('should not update the time context if continueTimeUpdate is false', () => {
             addDateTimeToContext(context, false);
-            expect(context.get('time.minute')).to.equal(12);
+            expect(context.get('dateTime.local.time.minute')).to.equal(12);
             clock.tick(60000);
-            expect(context.get('time.minute')).to.equal(12);
+            expect(context.get('dateTime.local.time.minute')).to.equal(12);
         });
 
         it('should update the time context every minute if no value passed in - default is true', () => {
             addDateTimeToContext(context);
-            expect(context.get('time.minute')).to.equal(12);
+            expect(context.get('dateTime.local.time.minute')).to.equal(12);
             clock.tick(60000);
-            expect(context.get('time.minute')).to.equal(13);
+            expect(context.get('dateTime.local.time.minute')).to.equal(13);
         });
 
         it('should update the time context every minute', () => {
             addDateTimeToContext(context, true);
-            expect(context.get('time.minute')).to.equal(12);
+            expect(context.get('dateTime.local.time.minute')).to.equal(12);
             clock.tick(60000);
-            expect(context.get('time.minute')).to.equal(13);
+            expect(context.get('dateTime.local.time.minute')).to.equal(13);
         });
     });
 });

--- a/src/time-context.js
+++ b/src/time-context.js
@@ -1,28 +1,28 @@
 const MINUTE_IN_MILLIS = 60 * 1000;
 
 const MINUTES = [
-    {key: ['time', 'minute'], value: 'getMinutes'},
-    {key: ['utc', 'time', 'minute'], value: 'getUTCMinutes'}
+    {key: ['dateTime', 'local', 'time', 'minute'], value: 'getMinutes'},
+    {key: ['dateTime', 'utc', 'time', 'minute'], value: 'getUTCMinutes'}
 ];
 const HOURS = [
-    {key: ['time', 'hour'], value: 'getHours'},
-    {key: ['utc', 'time', 'hour'], value: 'getUTCHours'},
-    {key: ['hourOfDay'], value: 'getHours'},
-    {key: ['utc', 'hourOfDay'], value: 'getUTCHours'}
+    {key: ['dateTime', 'local', 'time', 'hour'], value: 'getHours'},
+    {key: ['dateTime', 'utc', 'time', 'hour'], value: 'getUTCHours'},
+    {key: ['dateTime', 'local', 'hourOfDay'], value: 'getHours'},
+    {key: ['dateTime', 'utc', 'hourOfDay'], value: 'getUTCHours'}
 ];
 const DAYS = [
-    {key: ['date', 'day'], value: 'getDate'},
-    {key: ['utc', 'date', 'day'], value: 'getUTCDate'},
-    {key: ['dayOfWeek'], value: 'getDay'},
-    {key: ['utc', 'dayOfWeek'], value: 'getUTCDay'}
+    {key: ['dateTime', 'local', 'date', 'day'], value: 'getDate'},
+    {key: ['dateTime', 'utc', 'date', 'day'], value: 'getUTCDate'},
+    {key: ['dateTime', 'local', 'dayOfWeek'], value: 'getDay'},
+    {key: ['dateTime', 'utc', 'dayOfWeek'], value: 'getUTCDay'}
 ];
 const MONTHS = [
-    {key: ['date', 'month'], value: 'getMonth', transform: function(v) { return v+1; }},
-    {key: ['utc', 'date', 'month'], value: 'getUTCMonth', transform: function(v) { return v+1; }}
+    {key: ['dateTime', 'local', 'date', 'month'], value: 'getMonth', transform: function(v) { return v+1; }},
+    {key: ['dateTime', 'utc', 'date', 'month'], value: 'getUTCMonth', transform: function(v) { return v+1; }}
 ];
 const YEARS = [
-    {key: ['date', 'year'], value: 'getFullYear'},
-    {key: ['utc', 'date', 'year'], value: 'getUTCFullYear'}
+    {key: ['dateTime', 'local', 'date', 'year'], value: 'getFullYear'},
+    {key: ['dateTime', 'utc', 'date', 'year'], value: 'getUTCFullYear'}
 ];
 
 const UNITS = [MINUTES, HOURS, DAYS, MONTHS, YEARS];


### PR DESCRIPTION
The audience builder uses the schema `path` to set the hierarchy. We don't support custom paths, so this needed updating.