### PR TITLE
AP-3519 use a get request to send data back 

### DIFF
--- a/src/beacon.js
+++ b/src/beacon.js
@@ -171,6 +171,11 @@ export default function Emitter(endpoint, context, options) {
         transmit();
       }
     });
+
+    // This event is less reliable in when it is fired than visibilitychange - visibilitychange is not always present
+    // in old browsers.
+    // https://developer.mozilla.org/en-US/docs/Web/API/Navigator/sendBeacon#sending_analytics_at_the_end_of_a_session
+    window.addEventListener('pagehide', transmit);
   }
 
   this.unblockAndFlush = function() {

--- a/src/beacon.js
+++ b/src/beacon.js
@@ -2,7 +2,7 @@ import retrieve from './retrieve.js';
 import { assign, omitUndefined } from './ponyfills/objects.js';
 
 export const MAX_MESSAGE_SIZE = 2000;
-export const DELAY = 5000;
+export const DELAY = 100;
 const ENDPOINT_PATTERN = /\/(v\d+)\/\w+\/([a-z]+)$/i;
 const BATCH_SIZE = 25;
 

--- a/src/beacon.js
+++ b/src/beacon.js
@@ -1,8 +1,6 @@
 import retrieve from './retrieve.js';
 import { assign, omitUndefined } from './ponyfills/objects.js';
 
-
-// TODO check char count in prod --
 export const MAX_MESSAGE_SIZE = 2000;
 export const DELAY = 100;
 const ENDPOINT_PATTERN = /\/(v\d+)\/\w+\/([a-z]+)$/i;
@@ -74,16 +72,17 @@ export default function Emitter(endpoint, context, options) {
         cache: 'no-cache'
       };
 
+      let fetchUrl = url;
       if (usePost) {
         options.method = 'POST';
         options.body = data;
       } else {
         let preppedData = prepData(data);
         let params = new URLSearchParams(preppedData).toString();
-        url = url + '?' + params;
+        fetchUrl = url + '?' + params;
       }
 
-      window.fetch(url, options)
+      window.fetch(fetchUrl, options)
         .then(function(response) {
           if (!response.ok) {
             console.error('Evolv: Unable to send event beacon - HTTP error! Status: ' + response.status);

--- a/src/beacon.js
+++ b/src/beacon.js
@@ -2,7 +2,7 @@ import retrieve from './retrieve.js';
 import { assign, omitUndefined } from './ponyfills/objects.js';
 
 export const MAX_MESSAGE_SIZE = 2000;
-export const DELAY = 100;
+export const DELAY = 5000;
 const ENDPOINT_PATTERN = /\/(v\d+)\/\w+\/([a-z]+)$/i;
 const BATCH_SIZE = 25;
 
@@ -166,6 +166,7 @@ export default function Emitter(endpoint, context, options) {
   }
 
   if (typeof window !== 'undefined') {
+    /** @see {@link https://developer.mozilla.org/en-US/docs/Web/API/Document/visibilitychange_event#sending_end-of-session_analytics_on_transitioning_to_hidden} */
     window.addEventListener("visibilitychange", function transmitData() {
       if (window.visibilityState === "hidden") {
         transmit();

--- a/src/beacon.js
+++ b/src/beacon.js
@@ -54,6 +54,7 @@ export default function Emitter(endpoint, context, options) {
     let parsedData = JSON.parse(data);
     for (let key in parsedData) {
       if (typeof parsedData[key] === 'object') {
+        // Need to stringify as URLSearchParams will just print Object
         preppedData[key] = JSON.stringify(parsedData[key]);
       } else {
         preppedData[key] = parsedData[key];
@@ -64,7 +65,7 @@ export default function Emitter(endpoint, context, options) {
   }
 
   function send(url, data, sync, forceFailover = false) {
-    if (typeof window !== 'undefined' && window.fetch && !forceFailover) {
+    if (typeof window !== 'undefined' && window.fetch && !!URLSearchParams && !forceFailover) {
       let preppedData = prepData(data);
       let params = new URLSearchParams(preppedData).toString();
 

--- a/src/tests/index.test.js
+++ b/src/tests/index.test.js
@@ -634,15 +634,18 @@ describe('Evolv client integration tests', () => {
       expect(results.eventPayloads[0].messages[0].payload.eid).to.equal("0f39849197")
       expect(results.eventPayloads[1].messages[0].type).to.equal("lunch-time")
 
-      expect(results.analyticsPayloads.length).to.equal(1);
+      expect(results.analyticsPayloads.length).to.equal(2);
       expect(results.analyticsPayloads[0].uid).to.equal(uid);
 
-      const messages = results.analyticsPayloads[0].messages;
+      const messages1 = results.analyticsPayloads[0].messages;
+      const messages2 = results.analyticsPayloads[1].messages;
+      const messages = messages1.concat(messages2);
 
-      expect(messages.length).to.equal(18)
+      expect(messages1.length).to.equal(9)
+      expect(messages2.length).to.equal(9)
 
       expect(messages[0].type).to.equal("context.initialized")
-      expect(messages[0].payload).to.eql( {
+      expect(messages1[0].payload).to.eql( {
         "remote": true,
         "web": {
           "url": "https://www.lunch.com/dev1/index.html"
@@ -950,11 +953,11 @@ describe('Evolv client integration tests', () => {
 
       await new Promise(resolve => setTimeout(resolve, 1));
 
-      expect(results.analyticsPayloads.length).to.equal(1);
+      expect(results.analyticsPayloads.length).to.equal(2);
       expect(results.analyticsPayloads[0].uid).to.equal(uid);
 
       const messages = results.analyticsPayloads[0].messages;
-      expect(messages.length).to.equal(18);
+      expect(messages.length).to.equal(9);
       expect(messages[0].type).to.equal("context.initialized");
       expect(messages[0].payload).to.eql( {
         "remote": true,

--- a/src/tests/index.test.js
+++ b/src/tests/index.test.js
@@ -641,8 +641,8 @@ describe('Evolv client integration tests', () => {
       const messages2 = results.analyticsPayloads[1].messages;
       const messages = messages1.concat(messages2);
 
-      expect(messages1.length).to.equal(9)
-      expect(messages2.length).to.equal(9)
+      expect(messages1.length).to.equal(10)
+      expect(messages2.length).to.equal(8)
 
       expect(messages[0].type).to.equal("context.initialized")
       expect(messages1[0].payload).to.eql( {
@@ -957,7 +957,7 @@ describe('Evolv client integration tests', () => {
       expect(results.analyticsPayloads[0].uid).to.equal(uid);
 
       const messages = results.analyticsPayloads[0].messages;
-      expect(messages.length).to.equal(9);
+      expect(messages.length).to.equal(10);
       expect(messages[0].type).to.equal("context.initialized");
       expect(messages[0].payload).to.eql( {
         "remote": true,


### PR DESCRIPTION
GET requests are significantly cheaper than POSTs
Switch to fetch instead of beacon -- as beacon does not support get requests. Use keepalive to maintain the beacon functionality when a page is closed

Use visibilitychange as it is more reliable than before unload (https://developer.mozilla.org/en-US/docs/Web/API/Navigator/sendBeacon)

Fallback to xhr post on error OR call it immediately if the individual message size is too large

AP-3519